### PR TITLE
Add pdf to gemini feature

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -1385,19 +1385,19 @@
     //Rename to pdf in base64
     function _pdfToBase64(fileId) {
         if (!fileId || typeof fileId !== 'string' || fileId.trim() === '') {
-            Logger.log("Erreur : Identifiant de fichier invalide.");
+            Logger.log("Error: Invalid file identifier..");
             return null;
         }
 
         try {
-            // Récupérer le fichier PDF depuis Google Drive
+            // Retrieve the PDF file from Google Drive
             const file = DriveApp.getFileById(fileId);
             const pdfBlob = file.getBlob();
             const pdfBase64 = Utilities.base64Encode(pdfBlob.getBytes());
 
             return pdfBase64;
         } catch (error) {
-            Logger.log("Erreur lors de l'appel à l'API Gemini : " + error.toString());
+            Logger.log(" Error during the call to the Gemini API: " + error.toString());
             return null;
         }
     }

--- a/src/code.gs
+++ b/src/code.gs
@@ -404,7 +404,18 @@
                         parts: {
                             text: `You have access to the content of a pdf. Use it to answer the user's questions.`
                         }
-                    })
+                    });
+                } else {
+                    if (verbose) {
+                        console.warn(`Failed to process PDF with ID: ${pdfID}`);
+                    }
+                    // Optionally add a message to inform the user about the failure
+                    contents.push({
+                        role: "user",
+                        parts: {
+                            text: "Failed to process the requested PDF. Please verify the PDF ID and try again."
+                        }
+                    });
                 }
                 return this;
             };


### PR DESCRIPTION
Overview

This PR introduces a new feature that allows users to upload and analyze PDFs using the Gemini model. With this addition, users can send a PDF to Gemini, enabling them to ask questions and extract insights from the document seamlessly.

Key Changes
	•	Implemented a function to convert PDF to Base64 for proper handling in Gemini API.
	•	Added support for attaching PDFs to a Gemini chat session.
	•	Integrated a method to query the PDF content through Gemini after upload.
	•	Improved error handling for invalid or missing PDFs.

Benefits

✅ Users can analyze PDF content directly within Gemini.
✅ Supports extracting key insights from documents dynamically.
✅ Ensures smooth integration with existing chat functionalities.