### PR TITLE
Adds file-ingestion support so a user can upload a document or image,…

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,7 @@
+{
+  "timeZone": "Europe/Paris",
+  "dependencies": {
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}


### PR DESCRIPTION
Adds file-ingestion support so a user can upload a document or image, have it parsed server-side, and injected directly into Gemini’s reasoning context.

What’s new?
	•	Chat.addFile(fileId) – public API that pushes a Drive file (PDF, text, image, Google Docs/Sheets/Slides) into the Gemini prompt.
	•	_convertFileToGeminiInput() – helper that exports Google files to PDF when needed, base-64-encodes binaries, and returns structured parts + systemMessage ready for the Gemini payload.
	•	Graceful fall-backs: bad IDs or unsupported MIME types yield a user-visible warning instead of breaking the run.

Why?

Until now the assistant could only process plain text. This change lets end-users drop a contract, dataset, or screenshot into the chat and immediately ask questions about its content—no manual copy-paste required.