### PR TITLE
Use createOpenAIInputImageContent in addFile for image attachments

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -182,8 +182,10 @@ const GenAIApp = (function () {
         // OpenAI
         const contentObj = {};
         if (fileInfo.mimeType.startsWith("image/")) {
-          contentObj.type = "input_image";
-          contentObj.image_url = `data:${fileInfo.mimeType};base64,${blobToBase64}`;
+          Object.assign(
+            contentObj,
+            createOpenAIInputImageContent(fileInfo.mimeType, blobToBase64)
+          );
         }
         else {
           Object.assign(


### PR DESCRIPTION
### Motivation
- Centralize construction of the OpenAI image input payload and remove inline object assembly in `addFile`.
- Ensure consistent payload shape for images by delegating creation to the existing helper `createOpenAIInputImageContent`.

### Description
- Replaced the inline construction of `{ type: "input_image", image_url: ... }` inside `addFile` in `src/code.gs` with `Object.assign(contentObj, createOpenAIInputImageContent(fileInfo.mimeType, blobToBase64))`.
- The helper is invoked with the file MIME type and base64 payload so the returned object retains the exact same structure and behavior as before.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c259ab97dc83308e4cfa05dadd4451)