### PR TITLE
Add Code Interpreter tooling and generated file download support

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -56,6 +56,7 @@ const GenAIApp = (function () {
       this._codeInterpreterContainerId = null;
       this._generatedFiles = [];
       this._lastContainerId = null;
+      this._lastGeneratedDriveFileUrl = null;
       let compaction_enabled = false;
       let compaction_threshold = 10000;
 
@@ -453,6 +454,7 @@ const GenAIApp = (function () {
         last_response_id = null;
         this._generatedFiles = [];
         this._lastContainerId = null;
+        this._lastGeneratedDriveFileUrl = null;
 
         model = advancedParametersObject?.model ?? model;
         temperature = advancedParametersObject?.temperature ?? temperature;
@@ -539,6 +541,13 @@ const GenAIApp = (function () {
           this._generatedFiles = this._extractContainerFileCitations(responseMessage);
           if (this._generatedFiles.length > 0) {
             this._lastContainerId = this._generatedFiles[0].containerId;
+            const blob = this._downloadContainerFile(
+              this._generatedFiles[0].containerId,
+              this._generatedFiles[0].fileId,
+              this._generatedFiles[0].filename
+            );
+            const createdFile = DriveApp.createFile(blob);
+            this._lastGeneratedDriveFileUrl = createdFile.getUrl();
           }
 
           // OpenAI Responses API returns top-level "id"
@@ -630,6 +639,9 @@ const GenAIApp = (function () {
             }
             else {
               // if no function has been found, stop here
+              if (this._lastGeneratedDriveFileUrl) {
+                return this._lastGeneratedDriveFileUrl;
+              }
               return _extractOpenAIResponseText(responseMessage);
             }
           }
@@ -646,6 +658,9 @@ const GenAIApp = (function () {
             return part?.text || null;
           }
           else {
+            if (this._lastGeneratedDriveFileUrl) {
+              return this._lastGeneratedDriveFileUrl;
+            }
             return _extractOpenAIResponseText(responseMessage);
           }
         }
@@ -873,24 +888,6 @@ const GenAIApp = (function () {
           throw new Error("[GenAIApp] - Generated file not found. Provide a valid file ID or index from getGeneratedFiles().");
         }
         return this._downloadContainerFile(targetFile.containerId, targetFile.fileId, targetFile.filename);
-      };
-
-      /**
-       * Downloads a generated file from the last run and creates it in Google Drive.
-       * @param {string|number} [fileIdOrIndex] - OPTIONAL - File ID or index from getGeneratedFiles(). Defaults to first generated file.
-       * @returns {GoogleAppsScript.Drive.File} The created Drive file.
-       * @example
-       * const chat = GenAIApp.newChat()
-       *   .addFile(DriveApp.getFileById("YOUR_FILE_ID").getBlob())
-       *   .enableCodeInterpreter()
-       *   .addMessage("Process this file and generate an updated version.");
-       * chat.run({ model: "gpt-5.4" });
-       * const createdFile = chat.createGeneratedFileInDrive();
-       * Logger.log(createdFile.getId());
-       */
-      this.createGeneratedFileInDrive = function (fileIdOrIndex) {
-        const blob = this.downloadGeneratedFile(fileIdOrIndex);
-        return DriveApp.createFile(blob);
       };
 
       this.getContainerId = function () {

--- a/src/code.gs
+++ b/src/code.gs
@@ -1584,6 +1584,7 @@ const GenAIApp = (function () {
       const options = {
         method: method.toLowerCase(),
         headers: headers,
+        timeoutSeconds: 30 * 60, 
         muteHttpExceptions: true
       };
       if (payload !== null && payload !== undefined) {

--- a/src/code.gs
+++ b/src/code.gs
@@ -875,6 +875,24 @@ const GenAIApp = (function () {
         return this._downloadContainerFile(targetFile.containerId, targetFile.fileId, targetFile.filename);
       };
 
+      /**
+       * Downloads a generated file from the last run and creates it in Google Drive.
+       * @param {string|number} [fileIdOrIndex] - OPTIONAL - File ID or index from getGeneratedFiles(). Defaults to first generated file.
+       * @returns {GoogleAppsScript.Drive.File} The created Drive file.
+       * @example
+       * const chat = GenAIApp.newChat()
+       *   .addFile(DriveApp.getFileById("YOUR_FILE_ID").getBlob())
+       *   .enableCodeInterpreter()
+       *   .addMessage("Process this file and generate an updated version.");
+       * chat.run({ model: "gpt-5.4" });
+       * const createdFile = chat.createGeneratedFileInDrive();
+       * Logger.log(createdFile.getId());
+       */
+      this.createGeneratedFileInDrive = function (fileIdOrIndex) {
+        const blob = this.downloadGeneratedFile(fileIdOrIndex);
+        return DriveApp.createFile(blob);
+      };
+
       this.getContainerId = function () {
         if (this._lastContainerId) {
           return this._lastContainerId;

--- a/src/code.gs
+++ b/src/code.gs
@@ -779,27 +779,44 @@ const GenAIApp = (function () {
       }
 
       this._extractContainerFileCitations = function (response) {
-        if (!Array.isArray(response?.output)) {
+        if (!response || !Array.isArray(response.output)) {
           return [];
         }
-        const citations = [];
-        response.output.forEach(outputItem => {
-          const contentItems = Array.isArray(outputItem?.content) ? outputItem.content : [];
-          contentItems.forEach(contentItem => {
-            const annotations = Array.isArray(contentItem?.annotations) ? contentItem.annotations : [];
-            annotations.forEach(annotation => {
-              const citation = annotation?.container_file_citation;
-              if (citation?.container_id && citation?.file_id) {
-                citations.push({
-                  containerId: citation.container_id,
-                  fileId: citation.file_id,
-                  filename: citation.filename || null
-                });
-              }
-            });
-          });
-        });
-        return citations;
+        const citationsById = {};
+
+        const addCitation = (containerId, fileId, filename) => {
+          if (!containerId || !fileId) return;
+          citationsById[fileId] = {
+            containerId: containerId,
+            fileId: fileId,
+            filename: filename || citationsById[fileId]?.filename || null
+          };
+        };
+
+        const walk = (node) => {
+          if (!node) return;
+          if (Array.isArray(node)) {
+            node.forEach(walk);
+            return;
+          }
+          if (typeof node !== "object") return;
+
+          if (node.type === "container_file_citation") {
+            addCitation(node.container_id, node.file_id, node.filename);
+          }
+          if (node.container_file_citation) {
+            const c = node.container_file_citation;
+            addCitation(c.container_id, c.file_id, c.filename);
+          }
+          if (node.type === "container_file" && node.file_id) {
+            addCitation(node.container_id, node.file_id, node.filename);
+          }
+
+          Object.keys(node).forEach(key => walk(node[key]));
+        };
+
+        walk(response.output);
+        return Object.keys(citationsById).map(fileId => citationsById[fileId]);
       };
 
       this._downloadContainerFile = function (containerId, fileId, filename) {
@@ -840,10 +857,16 @@ const GenAIApp = (function () {
        */
       this.downloadGeneratedFile = function (fileIdOrIndex) {
         let targetFile;
+        if (fileIdOrIndex === undefined || fileIdOrIndex === null) {
+          targetFile = this._generatedFiles[0];
+        }
+        else if (typeof fileIdOrIndex === "string" && fileIdOrIndex.trim() === "") {
+          targetFile = this._generatedFiles[0];
+        }
         if (typeof fileIdOrIndex === "number") {
           targetFile = this._generatedFiles[fileIdOrIndex];
         }
-        else {
+        else if (typeof fileIdOrIndex === "string") {
           targetFile = this._generatedFiles.find(file => file.fileId === fileIdOrIndex);
         }
         if (!targetFile) {

--- a/src/code.gs
+++ b/src/code.gs
@@ -52,6 +52,10 @@ const GenAIApp = (function () {
       let browsing = false;
       let reasoning_effort = "medium";
       let knowledgeLink = [];
+      this._codeInterpreterEnabled = false;
+      this._codeInterpreterContainerId = null;
+      this._generatedFiles = [];
+      this._lastContainerId = null;
       let compaction_enabled = false;
       let compaction_threshold = 10000;
 
@@ -296,6 +300,28 @@ const GenAIApp = (function () {
       };
 
       /**
+       * Enables OpenAI Code Interpreter support for this chat.
+       * @param {string} [containerId] - OPTIONAL - Explicit container ID to reuse.
+       * @returns {Chat} - The current Chat instance.
+       * @example
+       * const chat = GenAIApp.newChat()
+       *   .addFile(DriveApp.getFileById("YOUR_FILE_ID").getBlob())
+       *   .enableCodeInterpreter()
+       *   .addMessage("Process this file and generate an updated version.");
+       * chat.run({ model: "gpt-5.4" });
+       * const generatedFiles = chat.getGeneratedFiles();
+       * const blob = chat.downloadGeneratedFile(0);
+       * DriveApp.createFile(blob);
+       */
+      this.enableCodeInterpreter = function (containerId) {
+        this._codeInterpreterEnabled = true;
+        if (containerId) {
+          this._codeInterpreterContainerId = containerId;
+        }
+        return this;
+      };
+
+      /**
        * Includes the content of a web page in the prompt sent to openAI
        * @param {string} url - the url of the webpage you want to fetch
        * @returns {Chat} - The current Chat instance.
@@ -425,6 +451,8 @@ const GenAIApp = (function () {
       this.run = function (advancedParametersObject) {
         this._lastUsage = null;
         last_response_id = null;
+        this._generatedFiles = [];
+        this._lastContainerId = null;
 
         model = advancedParametersObject?.model ?? model;
         temperature = advancedParametersObject?.temperature ?? temperature;
@@ -507,6 +535,10 @@ const GenAIApp = (function () {
               && this._lastUsage?.input_tokens > this._inputTokenWarningThreshold) {
               console.warn(`[GenAIApp] - Warning: input token usage (${this._lastUsage.input_tokens}) exceeded configured threshold (${this._inputTokenWarningThreshold}) for response ${responseMessage.id}`);
             }
+          }
+          this._generatedFiles = this._extractContainerFileCitations(responseMessage);
+          if (this._generatedFiles.length > 0) {
+            this._lastContainerId = this._generatedFiles[0].containerId;
           }
 
           // OpenAI Responses API returns top-level "id"
@@ -725,8 +757,107 @@ const GenAIApp = (function () {
           payload.tools.push(fileSearchTool);
           payload.include = ["file_search_call.results"];
         }
+
+        if (this._codeInterpreterEnabled) {
+          payload.parallel_tool_calls = false;
+          if (this._codeInterpreterContainerId) {
+            payload.tools.push({
+              type: "container",
+              container_id: this._codeInterpreterContainerId
+            });
+          }
+          else {
+            payload.tools.push({
+              type: "code_interpreter",
+              container: {
+                type: "auto"
+              }
+            });
+          }
+        }
         return payload;
       }
+
+      this._extractContainerFileCitations = function (response) {
+        if (!Array.isArray(response?.output)) {
+          return [];
+        }
+        const citations = [];
+        response.output.forEach(outputItem => {
+          const contentItems = Array.isArray(outputItem?.content) ? outputItem.content : [];
+          contentItems.forEach(contentItem => {
+            const annotations = Array.isArray(contentItem?.annotations) ? contentItem.annotations : [];
+            annotations.forEach(annotation => {
+              const citation = annotation?.container_file_citation;
+              if (citation?.container_id && citation?.file_id) {
+                citations.push({
+                  containerId: citation.container_id,
+                  fileId: citation.file_id,
+                  filename: citation.filename || null
+                });
+              }
+            });
+          });
+        });
+        return citations;
+      };
+
+      this._downloadContainerFile = function (containerId, fileId, filename) {
+        const endpointUrl = `${apiBaseUrl}/v1/containers/${containerId}/files/${fileId}/content`;
+        const response = _callGenAIApi(endpointUrl, null, "GET", true);
+        const blob = response.getBlob();
+        const contentType = response.getHeaders()["Content-Type"] || blob.getContentType();
+        if (contentType) {
+          blob.setContentType(contentType);
+        }
+        if (filename) {
+          blob.setName(filename);
+        }
+        return blob;
+      };
+
+      /**
+       * Returns generated files from the last run call.
+       * @returns {{containerId: string, fileId: string, filename: string}[]} Generated files metadata.
+       */
+      this.getGeneratedFiles = function () {
+        return this._generatedFiles;
+      };
+
+      /**
+       * Downloads a generated file from the last run.
+       * @param {string|number} fileIdOrIndex - File ID or index from getGeneratedFiles().
+       * @returns {Blob} Downloaded file blob that can be stored with DriveApp.createFile(blob).
+       * @example
+       * const chat = GenAIApp.newChat()
+       *   .addFile(DriveApp.getFileById("YOUR_FILE_ID").getBlob())
+       *   .enableCodeInterpreter()
+       *   .addMessage("Process this file and generate an updated version.");
+       * chat.run({ model: "gpt-5.4" });
+       * const files = chat.getGeneratedFiles();
+       * const blob = chat.downloadGeneratedFile(files[0].fileId);
+       * DriveApp.createFile(blob);
+       */
+      this.downloadGeneratedFile = function (fileIdOrIndex) {
+        let targetFile;
+        if (typeof fileIdOrIndex === "number") {
+          targetFile = this._generatedFiles[fileIdOrIndex];
+        }
+        else {
+          targetFile = this._generatedFiles.find(file => file.fileId === fileIdOrIndex);
+        }
+        if (!targetFile) {
+          throw new Error("[GenAIApp] - Generated file not found. Provide a valid file ID or index from getGeneratedFiles().");
+        }
+        return this._downloadContainerFile(targetFile.containerId, targetFile.fileId, targetFile.filename);
+      };
+
+      this.getContainerId = function () {
+        if (this._lastContainerId) {
+          return this._lastContainerId;
+        }
+        return this._generatedFiles[0]?.containerId || this._codeInterpreterContainerId || null;
+      };
 
       /**
        * Builds and returns a payload for a Gemini API call, configuring content, model parameters, 
@@ -1383,7 +1514,7 @@ const GenAIApp = (function () {
 * @returns {object} - The response message from the GenAI API.
 * @throws {Error} If the API call fails after the maximum number of retries.
 */
-  function _callGenAIApi(endpoint, payload) {
+  function _callGenAIApi(endpoint, payload, method = "post", returnRawResponse = false) {
     let authMethod = 'Bearer ' + openAIKey;
     if (endpoint.includes("google")) {
       if (geminiKey) {
@@ -1413,11 +1544,13 @@ const GenAIApp = (function () {
         headers['x-goog-api-key'] = geminiKey;
       }
       const options = {
-        method: 'post',
+        method: method.toLowerCase(),
         headers: headers,
-        payload: JSON.stringify(payload),
         muteHttpExceptions: true
       };
+      if (payload !== null && payload !== undefined) {
+        options.payload = JSON.stringify(payload);
+      }
 
       let response;
       // if the ErrorHandler library is loaded and supports backoff, use it (https://github.com/RomainVialard/ErrorHandler)
@@ -1441,6 +1574,9 @@ const GenAIApp = (function () {
       const responseCode = response.getResponseCode();
 
       if (responseCode === 200) {
+        if (returnRawResponse) {
+          return response;
+        }
         // The request was successful, exit the loop.
         const parsedResponse = JSON.parse(response.getContentText());
         if (endpoint.includes("google")) {

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -1,6 +1,8 @@
 const GPT_MODEL = "gpt-5.4";
 const REASONING_MODEL = "o4-mini";
 const GEMINI_MODEL = "gemini-2.5-pro";
+const TEST_CODE_INTERPRETER_XLSX_DRIVE_FILE_ID = "";
+const TEST_CODE_INTERPRETER_PDF_DRIVE_FILE_ID = "";
 
 // Run all tests
 function testAll() {
@@ -13,6 +15,13 @@ function testAll() {
   testVision();
   testMaximumAPICalls();
   testInputTokenWarning();
+  // OpenAI-only tests - require valid Drive file IDs.
+  if (TEST_CODE_INTERPRETER_XLSX_DRIVE_FILE_ID) {
+    testCodeInterpreterExcel(TEST_CODE_INTERPRETER_XLSX_DRIVE_FILE_ID);
+  }
+  if (TEST_CODE_INTERPRETER_PDF_DRIVE_FILE_ID) {
+    testCodeInterpreterPDF(TEST_CODE_INTERPRETER_PDF_DRIVE_FILE_ID);
+  }
 }
 
 
@@ -147,6 +156,36 @@ ${lowThresholdResponse}`);
   console.log(`Input token warning test (high threshold) response:
 ${highThresholdResponse}`);
   console.log("Input token warning test (high threshold): verify that no warning log was emitted.");
+}
+
+function testCodeInterpreterExcel(driveFileId) {
+  GenAIApp.setOpenAIAPIKey(OPEN_AI_API_KEY);
+  const inputBlob = DriveApp.getFileById(driveFileId).getBlob();
+  const chat = GenAIApp.newChat();
+  chat
+    .addFile(inputBlob)
+    .enableCodeInterpreter()
+    .addMessage("Add a new column at the end that calculates row totals for all numeric columns");
+  const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
+  console.log(`Code Interpreter Excel response:\n${response}`);
+  const outputBlob = chat.downloadGeneratedFile(0);
+  const createdFile = DriveApp.createFile(outputBlob);
+  console.log(`Generated Excel file created: ${createdFile.getId()}`);
+}
+
+function testCodeInterpreterPDF(driveFileId) {
+  GenAIApp.setOpenAIAPIKey(OPEN_AI_API_KEY);
+  const inputBlob = DriveApp.getFileById(driveFileId).getBlob();
+  const chat = GenAIApp.newChat();
+  chat
+    .addFile(inputBlob)
+    .enableCodeInterpreter()
+    .addMessage("Add a summary paragraph at the top of the document describing its main contents");
+  const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
+  console.log(`Code Interpreter PDF response:\n${response}`);
+  const outputBlob = chat.downloadGeneratedFile(0);
+  const createdFile = DriveApp.createFile(outputBlob);
+  console.log(`Generated PDF file created: ${createdFile.getId()}`);
 }
 
 // Weather function implementation

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -167,10 +167,8 @@ function testCodeInterpreterExcel(driveFileId) {
     .enableCodeInterpreter()
     .addMessage("Add a new column at the end that calculates row totals for all numeric columns. Then generate and attach the updated Excel file as output.");
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
-  console.log(`Code Interpreter Excel response:\n${response}`);
+  console.log(`Generated Excel file url: ${response}`);
   console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
-  const createdFile = chat.createGeneratedFileInDrive();
-  console.log(`Generated Excel file created: ${createdFile.getId()}`);
 }
 
 function testCodeInterpreterPDF(driveFileId) {
@@ -182,10 +180,8 @@ function testCodeInterpreterPDF(driveFileId) {
     .enableCodeInterpreter()
     .addMessage("Add a summary paragraph at the top of the document describing its main contents. Then generate and attach the updated PDF file as output.");
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
-  console.log(`Code Interpreter PDF response:\n${response}`);
+  console.log(`Generated PDF file url: ${response}`);
   console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
-  const createdFile = chat.createGeneratedFileInDrive();
-  console.log(`Generated PDF file created: ${createdFile.getId()}`);
 }
 
 // Weather function implementation

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -165,10 +165,11 @@ function testCodeInterpreterExcel(driveFileId) {
   chat
     .addFile(inputBlob)
     .enableCodeInterpreter()
-    .addMessage("Add a new column at the end that calculates row totals for all numeric columns");
+    .addMessage("Add a new column at the end that calculates row totals for all numeric columns. Then generate and attach the updated Excel file as output.");
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
   console.log(`Code Interpreter Excel response:\n${response}`);
-  const outputBlob = chat.downloadGeneratedFile(0);
+  console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
+  const outputBlob = chat.downloadGeneratedFile();
   const createdFile = DriveApp.createFile(outputBlob);
   console.log(`Generated Excel file created: ${createdFile.getId()}`);
 }
@@ -180,10 +181,11 @@ function testCodeInterpreterPDF(driveFileId) {
   chat
     .addFile(inputBlob)
     .enableCodeInterpreter()
-    .addMessage("Add a summary paragraph at the top of the document describing its main contents");
+    .addMessage("Add a summary paragraph at the top of the document describing its main contents. Then generate and attach the updated PDF file as output.");
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
   console.log(`Code Interpreter PDF response:\n${response}`);
-  const outputBlob = chat.downloadGeneratedFile(0);
+  console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
+  const outputBlob = chat.downloadGeneratedFile();
   const createdFile = DriveApp.createFile(outputBlob);
   console.log(`Generated PDF file created: ${createdFile.getId()}`);
 }

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -169,8 +169,7 @@ function testCodeInterpreterExcel(driveFileId) {
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
   console.log(`Code Interpreter Excel response:\n${response}`);
   console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
-  const outputBlob = chat.downloadGeneratedFile();
-  const createdFile = DriveApp.createFile(outputBlob);
+  const createdFile = chat.createGeneratedFileInDrive();
   console.log(`Generated Excel file created: ${createdFile.getId()}`);
 }
 
@@ -185,8 +184,7 @@ function testCodeInterpreterPDF(driveFileId) {
   const response = chat.run({ model: GPT_MODEL, max_tokens: 4000 });
   console.log(`Code Interpreter PDF response:\n${response}`);
   console.log(`Generated files:\n${JSON.stringify(chat.getGeneratedFiles())}`);
-  const outputBlob = chat.downloadGeneratedFile();
-  const createdFile = DriveApp.createFile(outputBlob);
+  const createdFile = chat.createGeneratedFileInDrive();
   console.log(`Generated PDF file created: ${createdFile.getId()}`);
 }
 


### PR DESCRIPTION
### Motivation
- Provide first-class Code Interpreter integration so chat workflows can request model-managed containers and retrieve generated files. 
- Allow reusing an explicit container ID or creating an automatic container and expose generated-file metadata for downstream storage. 
- Reuse existing API auth/retry infrastructure to fetch file content from OpenAI container endpoints. 

### Description
- Added Chat instance state: `_codeInterpreterEnabled`, `_codeInterpreterContainerId`, `_generatedFiles`, and `_lastContainerId`, plus a chainable `enableCodeInterpreter(containerId?)` method with JSDoc and example. 
- Updated OpenAI payload construction in `this._buildOpenAIPayload()` to append either a `{ type: "code_interpreter", container: { type: "auto" } }` tool when enabled or `{ type: "container", container_id: ... }` when a container ID is supplied, and set `parallel_tool_calls = false` when using the tool. 
- Implemented response parsing helper `this._extractContainerFileCitations(response)` to collect `{ containerId, fileId, filename }` entries and store them to `this._generatedFiles` after each `run()`, also capturing `_lastContainerId`. 
- Added download helper `this._downloadContainerFile(containerId, fileId, filename)` which fetches `https://api.openai.com/v1/containers/{containerId}/files/{fileId}/content` and returns a Blob with content type and filename applied. 
- Exposed public APIs `getGeneratedFiles()`, `downloadGeneratedFile(fileIdOrIndex)` and `getContainerId()` with JSDoc and usage examples. 
- Extended internal `_callGenAIApi()` to accept an HTTP `method` and `returnRawResponse` flag so the download helper can reuse existing auth/retry logic for GET file-content requests. 
- Added OpenAI-only test helpers in `src/testFunctions.gs`: `testCodeInterpreterExcel(driveFileId)` and `testCodeInterpreterPDF(driveFileId)`, and registered them behind configurable Drive file ID constants. 

### Testing
- Performed repository sanity checks including `git diff` and created a commit for the changes to `src/code.gs` and `src/testFunctions.gs`, and the commit succeeded. 
- Verified static edits by printing relevant file regions and diffs to ensure payload, helpers, and new functions are present. 
- Did not execute Apps Script runtime tests (`testCodeInterpreterExcel` / `testCodeInterpreterPDF`) because they require valid API keys and Drive file IDs and cannot run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1027b624688332b404d83f38fd0f09)