### PR TITLE
Add Gemini authentication-mode test entrypoint and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The **GenAIApp** library is a Google Apps Script library designed for creating, 
   - [Example 6: Extend a Chat with an MCP Connector](#example-6--extend-a-chat-with-an-mcp-connector)
   - [Example 7: Connect to a Custom MCP Server with setServerUrl()](#example-7--connect-to-a-custom-mcp-server-with-setserverurl)
   - [Example 8: Continue a Conversation with previous_response_id](#example-8--continue-a-conversation-with-previous_response_id)
+- [Testing authentication modes](#testing-authentication-modes)
 - [Contributing](#contributing)
 - [License](#license)
 - [Reference](#reference)
@@ -461,6 +462,31 @@ const secondAnswer = secondChat.run({ model: "gpt-5.4" });
 Logger.log(secondAnswer);
 ```
 
+## Testing authentication modes
+
+The library includes an Apps Script test entrypoint named `testConfiguredAuthenticationModes()` for explicitly validating the two Gemini authentication paths supported by GenAIApp:
+
+1. **API key authentication** through `GenAIApp.setGeminiAPIKey(...)`.
+2. **Vertex AI authentication** through `GenAIApp.setGeminiAuth(projectId, region)`.
+
+Each mode can be enabled independently with boolean switches so you can run only API-key tests, only Vertex AI tests, both modes, or neither mode while a path is temporarily blocked.
+
+| Switch | Default | Behavior |
+| --- | --- | --- |
+| `ENABLE_API_KEY_AUTH_TESTS` | `true` | Runs the Gemini API-key smoke test when `true`; logs a skip when `false`. |
+| `ENABLE_VERTEX_AI_AUTH_TESTS` | `false` | Runs the Gemini Vertex AI smoke test when `true`; logs a skip when `false`. |
+
+### Local Apps Script configuration
+
+Set these values as Apps Script **Script Properties** or define equivalent constants in your local test project. Do not print credential values in logs.
+
+| Name | Required when | Description |
+| --- | --- | --- |
+| `GEMINI_API_KEY` | `ENABLE_API_KEY_AUTH_TESTS=true` | Gemini API key used by the public Generative Language API test. |
+| `VERTEX_AI_GCP_PROJECT_ID` | `ENABLE_VERTEX_AI_AUTH_TESTS=true` | GCP project linked to the Apps Script project and enabled for Vertex AI. |
+| `VERTEX_AI_GCP_REGION` | Optional for Vertex AI | Vertex AI region such as `us-central1`; leave blank to use the global endpoint. |
+
+Run `testConfiguredAuthenticationModes()` from the Apps Script editor after setting the switches and credentials. Disabled modes log a clear skip message. Enabled modes fail before making an API call when required credentials/configuration are missing. The test code clears the opposite Gemini authentication setting before each smoke test so API-key coverage cannot accidentally pass through Vertex AI, and Vertex AI coverage cannot accidentally pass through the API-key path.
 
 ## Contributing
 

--- a/src/code.gs
+++ b/src/code.gs
@@ -2669,6 +2669,17 @@ const GenAIApp = (function () {
      */
     setPrivateInstanceBaseUrl: function (baseUrl) {
       privateInstanceBaseUrl = baseUrl;
+    },
+
+    /**
+     * Resets Gemini authentication state to default values.
+     * Clears API key, GCP project ID, and region settings.
+     * Useful for test isolation to prevent auth state from leaking between tests.
+     */
+    resetGeminiAuthState: function () {
+      geminiKey = "";
+      gcpProjectId = "";
+      region = "";
     }
   }
 })();

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -2,8 +2,147 @@ const GPT_MODEL = "gpt-5.4";
 const REASONING_MODEL = "o4-mini";
 const GEMINI_MODEL = "gemini-2.5-pro";
 
+const AUTH_TEST_CONFIG_KEYS = {
+  ENABLE_API_KEY_AUTH_TESTS: "ENABLE_API_KEY_AUTH_TESTS",
+  ENABLE_VERTEX_AI_AUTH_TESTS: "ENABLE_VERTEX_AI_AUTH_TESTS",
+  GEMINI_API_KEY: "GEMINI_API_KEY",
+  VERTEX_AI_GCP_PROJECT_ID: "VERTEX_AI_GCP_PROJECT_ID",
+  VERTEX_AI_GCP_REGION: "VERTEX_AI_GCP_REGION"
+};
+
+/**
+ * Reads test configuration from environment variables, Apps Script properties,
+ * or legacy global constants. This helper never logs credential values.
+ */
+function getAuthTestConfigValue(name, defaultValue) {
+  if (typeof process !== "undefined" && process.env && process.env[name] !== undefined) {
+    return process.env[name];
+  }
+
+  try {
+    const scriptProperties = PropertiesService.getScriptProperties();
+    const propertyValue = scriptProperties.getProperty(name);
+    if (propertyValue !== null && propertyValue !== undefined) {
+      return propertyValue;
+    }
+  }
+  catch (err) {
+    // PropertiesService is unavailable outside Apps Script. Fall through to
+    // constants/defaults so local syntax checks can still load this file.
+  }
+
+  if (name === AUTH_TEST_CONFIG_KEYS.ENABLE_API_KEY_AUTH_TESTS && typeof ENABLE_API_KEY_AUTH_TESTS !== "undefined") {
+    return ENABLE_API_KEY_AUTH_TESTS;
+  }
+  if (name === AUTH_TEST_CONFIG_KEYS.ENABLE_VERTEX_AI_AUTH_TESTS && typeof ENABLE_VERTEX_AI_AUTH_TESTS !== "undefined") {
+    return ENABLE_VERTEX_AI_AUTH_TESTS;
+  }
+  if (name === AUTH_TEST_CONFIG_KEYS.GEMINI_API_KEY && typeof GEMINI_API_KEY !== "undefined") {
+    return GEMINI_API_KEY;
+  }
+  if (name === AUTH_TEST_CONFIG_KEYS.VERTEX_AI_GCP_PROJECT_ID && typeof VERTEX_AI_GCP_PROJECT_ID !== "undefined") {
+    return VERTEX_AI_GCP_PROJECT_ID;
+  }
+  if (name === AUTH_TEST_CONFIG_KEYS.VERTEX_AI_GCP_REGION && typeof VERTEX_AI_GCP_REGION !== "undefined") {
+    return VERTEX_AI_GCP_REGION;
+  }
+
+  return defaultValue;
+}
+
+function getAuthTestBoolean(name, defaultValue) {
+  const rawValue = getAuthTestConfigValue(name, defaultValue ? "true" : "false");
+  if (typeof rawValue === "boolean") {
+    return rawValue;
+  }
+  return String(rawValue).toLowerCase() === "true";
+}
+
+function requireAuthTestCredential(name, modeName) {
+  const value = getAuthTestConfigValue(name, "");
+  if (!value) {
+    throw new Error(`[GenAIApp tests] ${modeName} tests are enabled, but required credential/configuration ${name} is missing.`);
+  }
+  return value;
+}
+
+function skipAuthTest(modeName, reason) {
+  console.log(`[GenAIApp tests] Skipping ${modeName} authentication tests: ${reason}`);
+}
+
+/**
+ * Stores auth-test switches in script properties before running the Apps Script
+ * test entrypoint. Do not pass raw secrets through this function.
+ */
+function configureAuthTestSwitches(enableApiKeyAuthTests, enableVertexAiAuthTests) {
+  PropertiesService.getScriptProperties().setProperties({
+    ENABLE_API_KEY_AUTH_TESTS: String(enableApiKeyAuthTests),
+    ENABLE_VERTEX_AI_AUTH_TESTS: String(enableVertexAiAuthTests)
+  });
+}
+
+/**
+ * Entrypoint for authentication coverage. Set ENABLE_API_KEY_AUTH_TESTS and
+ * ENABLE_VERTEX_AI_AUTH_TESTS independently to run API-key auth, Vertex AI
+ * auth, both, or neither. Disabled modes log a clear skip. Enabled modes fail
+ * before calling the API when required credentials/configuration are absent.
+ */
+function testConfiguredAuthenticationModes() {
+  const runApiKeyAuthTests = getAuthTestBoolean(AUTH_TEST_CONFIG_KEYS.ENABLE_API_KEY_AUTH_TESTS, true);
+  const runVertexAiAuthTests = getAuthTestBoolean(AUTH_TEST_CONFIG_KEYS.ENABLE_VERTEX_AI_AUTH_TESTS, false);
+
+  if (!runApiKeyAuthTests && !runVertexAiAuthTests) {
+    console.log("[GenAIApp tests] All Gemini authentication-mode tests are disabled.");
+    return;
+  }
+
+  if (runApiKeyAuthTests) {
+    testApiKeyAuthentication();
+  }
+  else {
+    skipAuthTest("API key", "ENABLE_API_KEY_AUTH_TESTS is not true");
+  }
+
+  if (runVertexAiAuthTests) {
+    testVertexAiAuthentication();
+  }
+  else {
+    skipAuthTest("Vertex AI", "ENABLE_VERTEX_AI_AUTH_TESTS is not true");
+  }
+}
+
+function testApiKeyAuthentication() {
+  const geminiApiKey = requireAuthTestCredential(AUTH_TEST_CONFIG_KEYS.GEMINI_API_KEY, "API key authentication");
+
+  // Force the Gemini public API-key path and clear Vertex settings so this
+  // test cannot accidentally pass with Vertex AI credentials.
+  GenAIApp.setGeminiAuth(null, null);
+  GenAIApp.setGeminiAPIKey(geminiApiKey);
+
+  const chat = GenAIApp.newChat();
+  chat.addMessage("Reply with exactly: API key authentication ok");
+  const response = chat.run({ model: GEMINI_MODEL, max_tokens: 64 });
+  console.log(`[GenAIApp tests] API key authentication completed with response length ${String(response).length}.`);
+}
+
+function testVertexAiAuthentication() {
+  const projectId = requireAuthTestCredential(AUTH_TEST_CONFIG_KEYS.VERTEX_AI_GCP_PROJECT_ID, "Vertex AI authentication");
+  const vertexRegion = getAuthTestConfigValue(AUTH_TEST_CONFIG_KEYS.VERTEX_AI_GCP_REGION, "");
+
+  // Force the Vertex AI path and clear any Gemini API key so this test cannot
+  // accidentally pass through the Generative Language API.
+  GenAIApp.setGeminiAPIKey(null);
+  GenAIApp.setGeminiAuth(projectId, vertexRegion);
+
+  const chat = GenAIApp.newChat();
+  chat.addMessage("Reply with exactly: Vertex AI authentication ok");
+  const response = chat.run({ model: GEMINI_MODEL, max_tokens: 64 });
+  console.log(`[GenAIApp tests] Vertex AI authentication completed with response length ${String(response).length}.`);
+}
+
 // Run all tests
 function testAll() {
+  testConfiguredAuthenticationModes();
   testSimpleChatInstance();
   testFunctionCalling();
   testFunctionCallingEndWithResult();

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -143,6 +143,7 @@ function testVertexAiAuthentication() {
 // Run all tests
 function testAll() {
   testConfiguredAuthenticationModes();
+  GenAIApp.resetGeminiAuthState();
   testSimpleChatInstance();
   testFunctionCalling();
   testFunctionCallingEndWithResult();


### PR DESCRIPTION
### Motivation

- Provide reproducible smoke tests to validate both Gemini authentication paths (API key and Vertex AI) and document how to run them.

### Description

- Add `testConfiguredAuthenticationModes()` and helper functions (`getAuthTestConfigValue`, `getAuthTestBoolean`, `requireAuthTestCredential`, `skipAuthTest`, `configureAuthTestSwitches`, `testApiKeyAuthentication`, and `testVertexAiAuthentication`) to `src/testFunctions.gs` for configurable authentication-mode testing.
- Introduce `AUTH_TEST_CONFIG_KEYS` constants and wire `testConfiguredAuthenticationModes()` into `testAll()` so auth-mode checks run with the existing test harness.
- Update `README.md` to include a "Testing authentication modes" section describing the entrypoint, boolean switches, required Apps Script Script Properties, and how to run the test entrypoint from the Apps Script editor.
- Tests are designed to avoid leaking secrets and explicitly clear the opposite auth configuration before each smoke test so each path is exercised independently.

### Testing

- No automated CI tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a268be05fac8332ae1c02a87f74e444)