### PR TITLE
Support spreadsheet attachments: convert XLSX/Sheets/ODS/XLS to CSV for Gemini

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -168,25 +168,53 @@ const GenAIApp = (function () {
         if (typeof fileInput == 'string') {
           // assume the input is a Google Drive ID
           sourceFileId = fileInput;
-          fileInfo = this._getBlobFromGoogleDrive(fileInput);
-          blobToBase64 = Utilities.base64Encode(fileInfo.blob.getBytes());
+          const file = DriveApp.getFileById(fileInput);
+          fileInfo = {
+            mimeType: file.getMimeType(),
+            fileName: file.getName()
+          };
+          if (!_isSpreadsheetMimeType(fileInfo.mimeType)) {
+            fileInfo = this._getBlobFromGoogleDrive(fileInput);
+            blobToBase64 = Utilities.base64Encode(fileInfo.blob.getBytes());
+          }
         }
         else if (isBlobLike(fileInput)) {
           // the input is a Blob
           sourceBlob = fileInput;
-          const fileBytes = fileInput.getBytes();
-          const fileSize = fileBytes.length;
-          if (fileSize > MAX_FILE_SIZE) {
-            throw new Error(`File too large (${fileSize} bytes). Maximum allowed size is ${MAX_FILE_SIZE} bytes.`);
-          }
-          blobToBase64 = Utilities.base64Encode(fileBytes);
           fileInfo = {
             mimeType: fileInput.getContentType(),
             fileName: fileInput.getName()
           };
+          if (!_isSpreadsheetMimeType(fileInfo.mimeType)) {
+            const fileBytes = fileInput.getBytes();
+            const fileSize = fileBytes.length;
+            if (fileSize > MAX_FILE_SIZE) {
+              throw new Error(`File too large (${fileSize} bytes). Maximum allowed size is ${MAX_FILE_SIZE} bytes.`);
+            }
+            blobToBase64 = Utilities.base64Encode(fileBytes);
+          }
         }
         else {
           throw new Error('Invalid file input provided to addFile() method. Please provide a valid Google Drive file ID or a Blob.');
+        }
+
+        if (_isSpreadsheetMimeType(fileInfo.mimeType)) {
+          const lazySpreadsheetPart = {
+            _needsSpreadsheetConversion: true,
+            _sourceFileId: sourceFileId,
+            _sourceBlob: sourceBlob,
+            _mimeType: fileInfo.mimeType,
+            _fileName: fileInfo.fileName
+          };
+          messages.push({
+            role: "user",
+            content: [lazySpreadsheetPart]
+          });
+          contents.push({
+            role: 'user',
+            parts: [lazySpreadsheetPart]
+          });
+          return this;
         }
 
         // OpenAI
@@ -208,30 +236,15 @@ const GenAIApp = (function () {
           content: [contentObj]
         });
 
-        // Gemini - defer spreadsheet conversion until _buildGeminiPayload
-        if (_isSpreadsheetMimeType(fileInfo.mimeType)) {
-          // Mark for lazy conversion - store metadata instead of converting now
-          contents.push({
-            role: 'user',
-            parts: [{
-              _needsSpreadsheetConversion: true,
-              _sourceFileId: sourceFileId,
-              _sourceBlob: sourceBlob || fileInfo.blob,
-              _mimeType: fileInfo.mimeType
-            }]
-          });
-        } else {
-          // Non-spreadsheet files can be encoded immediately
-          contents.push({
-            role: 'user',
-            parts: [{
-              inline_data: {
-                mime_type: fileInfo.mimeType,
-                data: blobToBase64
-              }
-            }]
-          });
-        }
+        contents.push({
+          role: 'user',
+          parts: [{
+            inline_data: {
+              mime_type: fileInfo.mimeType,
+              data: blobToBase64
+            }
+          }]
+        });
         return this;
       };
 
@@ -738,12 +751,45 @@ const GenAIApp = (function () {
 
         let systemInstructions = "";
         const userMessages = [];
+        const resolveOpenAIContentPart = (part) => {
+          if (!part?._needsSpreadsheetConversion) {
+            return part;
+          }
+
+          const fileInfo = part._sourceFileId
+            ? this._getBlobFromGoogleDrive(part._sourceFileId)
+            : {
+              blob: part._sourceBlob,
+              mimeType: part._mimeType,
+              fileName: part._fileName
+            };
+          const fileBytes = fileInfo.blob.getBytes();
+          const fileSize = fileBytes.length;
+          if (fileSize > MAX_FILE_SIZE) {
+            throw new Error(`File too large (${fileSize} bytes). Maximum allowed size is ${MAX_FILE_SIZE} bytes.`);
+          }
+
+          return createOpenAIInputFileContent(
+            fileInfo.mimeType,
+            Utilities.base64Encode(fileBytes),
+            fileInfo.fileName
+          );
+        };
+
         for (const message of messages) {
           if (message.role === "system") {
             systemInstructions += message.content + "\n";
           }
           else {
-            userMessages.push(message);
+            if (Array.isArray(message.content)) {
+              userMessages.push({
+                ...message,
+                content: message.content.map(resolveOpenAIContentPart)
+              });
+            }
+            else {
+              userMessages.push(message);
+            }
           }
         }
         if (systemInstructions !== "") {
@@ -1030,9 +1076,14 @@ const GenAIApp = (function () {
             const processedParts = content.parts.map(part => {
               if (part._needsSpreadsheetConversion) {
                 // Perform lazy spreadsheet conversion here
-                const csvResult = part._sourceFileId && part._mimeType === 'application/vnd.google-apps.spreadsheet'
-                  ? _exportGoogleSheetsToCsv(part._sourceFileId)
-                  : _convertXlsxBlobToCsv(part._sourceBlob);
+                let csvResult;
+                if (part._sourceFileId && part._mimeType === 'application/vnd.google-apps.spreadsheet') {
+                  csvResult = _exportGoogleSheetsToCsv(part._sourceFileId);
+                }
+                else {
+                  const sourceBlob = part._sourceBlob || (part._sourceFileId ? DriveApp.getFileById(part._sourceFileId).getBlob() : null);
+                  csvResult = _convertXlsxBlobToCsv(sourceBlob);
+                }
                 const csvWithMetadata = _formatSpreadsheetCsvForGemini(csvResult);
 
                 // Issue 2: Validate CSV size before base64 encoding

--- a/src/code.gs
+++ b/src/code.gs
@@ -162,14 +162,18 @@ const GenAIApp = (function () {
       this.addFile = function (fileInput) {
         let fileInfo;
         let blobToBase64;
+        let sourceFileId = null;
+        let sourceBlob = null;
 
         if (typeof fileInput == 'string') {
           // assume the input is a Google Drive ID
+          sourceFileId = fileInput;
           fileInfo = this._getBlobFromGoogleDrive(fileInput);
           blobToBase64 = Utilities.base64Encode(fileInfo.blob.getBytes());
         }
         else if (isBlobLike(fileInput)) {
           // the input is a Blob
+          sourceBlob = fileInput;
           const fileBytes = fileInput.getBytes();
           const fileSize = fileBytes.length;
           if (fileSize > MAX_FILE_SIZE) {
@@ -205,12 +209,23 @@ const GenAIApp = (function () {
         });
 
         // Gemini
+        let geminiMimeType = fileInfo.mimeType;
+        let geminiBase64Data = blobToBase64;
+        if (_isSpreadsheetMimeType(fileInfo.mimeType)) {
+          const csvResult = sourceFileId && fileInfo.mimeType === 'application/vnd.google-apps.spreadsheet'
+            ? _exportGoogleSheetsToCsv(sourceFileId)
+            : _convertXlsxBlobToCsv(sourceBlob || fileInfo.blob);
+          const csvWithMetadata = _formatSpreadsheetCsvForGemini(csvResult);
+          geminiMimeType = 'text/csv';
+          geminiBase64Data = Utilities.base64Encode(csvWithMetadata);
+        }
+
         contents.push({
           role: 'user',
           parts: [{
             inline_data: {
-              mime_type: fileInfo.mimeType,
-              data: blobToBase64
+              mime_type: geminiMimeType,
+              data: geminiBase64Data
             }
           }]
         });
@@ -1097,6 +1112,9 @@ const GenAIApp = (function () {
           case 'image/jpeg':
           case 'image/gif':
           case 'image/webp':
+          case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+          case 'application/vnd.ms-excel':
+          case 'application/vnd.oasis.opendocument.spreadsheet':
             blob = file.getBlob();
             break;
 
@@ -2143,6 +2161,23 @@ const GenAIApp = (function () {
     typeof x.getBytes === "function" &&
     typeof x.getContentType === "function";
 
+  /**
+   * Returns true when a MIME type identifies a spreadsheet file that can be
+   * converted to CSV for Gemini prompts.
+   *
+   * @private
+   * @param {string} mimeType - MIME type to inspect.
+   * @returns {boolean} Whether the MIME type is a supported spreadsheet.
+   */
+  function _isSpreadsheetMimeType(mimeType) {
+    return [
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.google-apps.spreadsheet',
+      'application/vnd.ms-excel',
+      'application/vnd.oasis.opendocument.spreadsheet'
+    ].includes(mimeType);
+  }
+
   // OpenAI-only helper: creates a Responses API input_file content object.
   const createOpenAIInputFileContent = (mimeType, base64Data, filename) => ({
     type: "input_file",
@@ -2171,6 +2206,168 @@ const GenAIApp = (function () {
       blob.getName()
     );
   };
+
+  const MAX_SPREADSHEET_CELLS = 500000;
+
+  /**
+   * Converts an uploaded XLSX blob into CSV text by temporarily converting it to
+   * a native Google Sheets file.
+   *
+   * @private
+   * @param {Blob} blob - The XLSX blob to convert.
+   * @returns {{csvText: string, originalFilename: string, sheetNames: string[]}} Conversion result and metadata.
+   */
+  function _convertXlsxBlobToCsv(blob) {
+    if (!isBlobLike(blob)) {
+      throw new Error('[GenAIApp] - Invalid XLSX input. Please provide a valid Blob.');
+    }
+
+    const originalFilename = blob.getName() || 'spreadsheet.xlsx';
+    _assertBlobSizeWithinLimit(blob, originalFilename);
+
+    let convertedFile;
+    try {
+      const conversionBlob = blob.copyBlob()
+        .setName(originalFilename)
+        .setContentType(MimeType.GOOGLE_SHEETS);
+      convertedFile = DriveApp.createFile(conversionBlob);
+
+      const spreadsheet = SpreadsheetApp.openById(convertedFile.getId());
+      return _spreadsheetToCsvResult(spreadsheet, originalFilename);
+    }
+    finally {
+      if (convertedFile) {
+        convertedFile.setTrashed(true);
+      }
+    }
+  }
+
+  /**
+   * Exports a native Google Sheets file to concatenated CSV text. Hidden and
+   * empty sheets are omitted.
+   *
+   * @private
+   * @param {string} fileId - The Google Sheets Drive file ID.
+   * @returns {{csvText: string, originalFilename: string, sheetNames: string[]}} Export result and metadata.
+   */
+  function _exportGoogleSheetsToCsv(fileId) {
+    const file = DriveApp.getFileById(fileId);
+    const fileSize = file.getSize();
+    if (fileSize > MAX_FILE_SIZE) {
+      throw new Error(`[GenAIApp] - Spreadsheet file too large (${fileSize} bytes). Maximum allowed size is ${MAX_FILE_SIZE} bytes.`);
+    }
+
+    const spreadsheet = SpreadsheetApp.openById(fileId);
+    return _spreadsheetToCsvResult(spreadsheet, file.getName());
+  }
+
+  /**
+   * Converts a two-dimensional array to RFC 4180-compatible CSV text.
+   *
+   * @private
+   * @param {Array[]} dataArray - Two-dimensional row/cell array.
+   * @returns {string} CSV text.
+   */
+  function _arrayToCsv(dataArray) {
+    if (!dataArray || dataArray.length === 0) {
+      return '';
+    }
+
+    return dataArray.map(row => {
+      const cells = Array.isArray(row) ? row : [row];
+      return cells.map(cell => {
+        const value = cell === null || typeof cell === 'undefined' ? '' : String(cell);
+        const escapedValue = value.replace(/"/g, '""');
+        return /[",\r\n]/.test(value) ? `"${escapedValue}"` : escapedValue;
+      }).join(',');
+    }).join('\n');
+  }
+
+  /**
+   * Creates a concatenated CSV export from visible, non-empty spreadsheet sheets.
+   *
+   * @private
+   * @param {Spreadsheet} spreadsheet - The spreadsheet to export.
+   * @param {string} originalFilename - Source filename for metadata.
+   * @returns {{csvText: string, originalFilename: string, sheetNames: string[]}} CSV export and metadata.
+   */
+  function _spreadsheetToCsvResult(spreadsheet, originalFilename) {
+    const csvSections = [];
+    const sheetNames = [];
+    let totalCells = 0;
+
+    spreadsheet.getSheets().forEach(sheet => {
+      if (sheet.isSheetHidden()) {
+        return;
+      }
+
+      const lastRow = sheet.getLastRow();
+      const lastColumn = sheet.getLastColumn();
+      if (lastRow === 0 || lastColumn === 0) {
+        return;
+      }
+
+      totalCells += lastRow * lastColumn;
+      if (totalCells > MAX_SPREADSHEET_CELLS) {
+        throw new Error(`[GenAIApp] - Spreadsheet too large to convert (${totalCells} populated-range cells). Maximum allowed is ${MAX_SPREADSHEET_CELLS} cells.`);
+      }
+
+      const values = sheet.getDataRange().getValues();
+      if (_isEmptySheetData(values)) {
+        return;
+      }
+
+      sheetNames.push(sheet.getName());
+      csvSections.push(`--- Sheet: ${sheet.getName()} ---\n${_arrayToCsv(values)}`);
+    });
+
+    return {
+      csvText: csvSections.join('\n\n'),
+      originalFilename: originalFilename,
+      sheetNames: sheetNames
+    };
+  }
+
+  /**
+   * Formats converted spreadsheet CSV with a filename/sheet metadata preamble for Gemini.
+   *
+   * @private
+   * @param {{csvText: string, originalFilename: string, sheetNames: string[]}} csvResult - Spreadsheet CSV result.
+   * @returns {string} CSV text prefixed with spreadsheet metadata.
+   */
+  function _formatSpreadsheetCsvForGemini(csvResult) {
+    const sheetNames = csvResult.sheetNames && csvResult.sheetNames.length > 0
+      ? csvResult.sheetNames.join(', ')
+      : 'None';
+    return `[Spreadsheet: ${csvResult.originalFilename} | Sheets: ${sheetNames}]\n\n${csvResult.csvText}`;
+  }
+
+  /**
+   * Throws when a blob exceeds the shared maximum file size.
+   *
+   * @private
+   * @param {Blob} blob - Blob to check.
+   * @param {string} filename - Filename used in the error message.
+   */
+  function _assertBlobSizeWithinLimit(blob, filename) {
+    const fileSize = blob.getBytes().length;
+    if (fileSize > MAX_FILE_SIZE) {
+      throw new Error(`[GenAIApp] - Spreadsheet file too large (${filename}, ${fileSize} bytes). Maximum allowed size is ${MAX_FILE_SIZE} bytes.`);
+    }
+  }
+
+  /**
+   * Returns true when a sheet data array contains no non-empty values.
+   *
+   * @private
+   * @param {Array[]} values - Sheet values from getValues().
+   * @returns {boolean} Whether the sheet data is empty.
+   */
+  function _isEmptySheetData(values) {
+    return !values || values.length === 0 || values.every(row =>
+      !row || row.every(cell => cell === null || typeof cell === 'undefined' || cell === '')
+    );
+  }
 
   /**
    * Uploads a file to OpenAI and returns the file ID.

--- a/src/code.gs
+++ b/src/code.gs
@@ -208,27 +208,30 @@ const GenAIApp = (function () {
           content: [contentObj]
         });
 
-        // Gemini
-        let geminiMimeType = fileInfo.mimeType;
-        let geminiBase64Data = blobToBase64;
+        // Gemini - defer spreadsheet conversion until _buildGeminiPayload
         if (_isSpreadsheetMimeType(fileInfo.mimeType)) {
-          const csvResult = sourceFileId && fileInfo.mimeType === 'application/vnd.google-apps.spreadsheet'
-            ? _exportGoogleSheetsToCsv(sourceFileId)
-            : _convertXlsxBlobToCsv(sourceBlob || fileInfo.blob);
-          const csvWithMetadata = _formatSpreadsheetCsvForGemini(csvResult);
-          geminiMimeType = 'text/csv';
-          geminiBase64Data = Utilities.base64Encode(csvWithMetadata);
+          // Mark for lazy conversion - store metadata instead of converting now
+          contents.push({
+            role: 'user',
+            parts: [{
+              _needsSpreadsheetConversion: true,
+              _sourceFileId: sourceFileId,
+              _sourceBlob: sourceBlob || fileInfo.blob,
+              _mimeType: fileInfo.mimeType
+            }]
+          });
+        } else {
+          // Non-spreadsheet files can be encoded immediately
+          contents.push({
+            role: 'user',
+            parts: [{
+              inline_data: {
+                mime_type: fileInfo.mimeType,
+                data: blobToBase64
+              }
+            }]
+          });
         }
-
-        contents.push({
-          role: 'user',
-          parts: [{
-            inline_data: {
-              mime_type: geminiMimeType,
-              data: geminiBase64Data
-            }
-          }]
-        });
         return this;
       };
 
@@ -1021,8 +1024,42 @@ const GenAIApp = (function () {
        * @throws {Error} If an incompatible feature is selected (e.g., assistant usage with the Gemini model).
        */
       this._buildGeminiPayload = function (advancedParametersObject) {
+        // Process contents array to handle lazy spreadsheet conversion
+        const processedContents = contents.map(content => {
+          if (content.role === 'user' && content.parts) {
+            const processedParts = content.parts.map(part => {
+              if (part._needsSpreadsheetConversion) {
+                // Perform lazy spreadsheet conversion here
+                const csvResult = part._sourceFileId && part._mimeType === 'application/vnd.google-apps.spreadsheet'
+                  ? _exportGoogleSheetsToCsv(part._sourceFileId)
+                  : _convertXlsxBlobToCsv(part._sourceBlob);
+                const csvWithMetadata = _formatSpreadsheetCsvForGemini(csvResult);
+
+                // Issue 2: Validate CSV size before base64 encoding
+                const csvByteLength = Utilities.newBlob(csvWithMetadata).getBytes().length;
+                const base64Size = Math.ceil(csvByteLength * 4 / 3);
+                const MAX_INLINE_UPLOAD_SIZE = 20 * 1024 * 1024; // 20 MB
+
+                if (base64Size > MAX_INLINE_UPLOAD_SIZE) {
+                  throw new Error(`[GenAIApp] - Spreadsheet CSV too large after conversion (${base64Size} bytes base64-encoded). Maximum allowed size for inline upload is ${MAX_INLINE_UPLOAD_SIZE} bytes.`);
+                }
+
+                return {
+                  inline_data: {
+                    mime_type: 'text/csv',
+                    data: Utilities.base64Encode(csvWithMetadata)
+                  }
+                };
+              }
+              return part;
+            });
+            return { ...content, parts: processedParts };
+          }
+          return content;
+        });
+
         const payload = {
-          'contents': contents,
+          'contents': processedContents,
           'model': model,
           'generationConfig': {
             maxOutputTokens: max_tokens,
@@ -2225,19 +2262,24 @@ const GenAIApp = (function () {
     const originalFilename = blob.getName() || 'spreadsheet.xlsx';
     _assertBlobSizeWithinLimit(blob, originalFilename);
 
-    let convertedFile;
+    let convertedFileId;
     try {
-      const conversionBlob = blob.copyBlob()
-        .setName(originalFilename)
-        .setContentType(MimeType.GOOGLE_SHEETS);
-      convertedFile = DriveApp.createFile(conversionBlob);
+      // Use Advanced Drive Service to perform XLSX → Google Sheets conversion
+      const resource = {
+        title: originalFilename,
+        mimeType: MimeType.GOOGLE_SHEETS
+      };
+      const file = Drive.Files.insert(resource, blob, {
+        convert: true
+      });
+      convertedFileId = file.id;
 
-      const spreadsheet = SpreadsheetApp.openById(convertedFile.getId());
+      const spreadsheet = SpreadsheetApp.openById(convertedFileId);
       return _spreadsheetToCsvResult(spreadsheet, originalFilename);
     }
     finally {
-      if (convertedFile) {
-        convertedFile.setTrashed(true);
+      if (convertedFileId) {
+        Drive.Files.remove(convertedFileId);
       }
     }
   }
@@ -2312,7 +2354,7 @@ const GenAIApp = (function () {
         throw new Error(`[GenAIApp] - Spreadsheet too large to convert (${totalCells} populated-range cells). Maximum allowed is ${MAX_SPREADSHEET_CELLS} cells.`);
       }
 
-      const values = sheet.getDataRange().getValues();
+      const values = sheet.getDataRange().getDisplayValues();
       if (_isEmptySheetData(values)) {
         return;
       }

--- a/src/code.gs
+++ b/src/code.gs
@@ -2310,6 +2310,10 @@ const GenAIApp = (function () {
       throw new Error('[GenAIApp] - Invalid XLSX input. Please provide a valid Blob.');
     }
 
+    if (typeof Drive === 'undefined' || !Drive.Files || typeof Drive.Files.insert !== 'function') {
+      throw new Error('[GenAIApp] - Advanced Drive Service is required for XLSX to CSV conversion. Please enable it in your Apps Script project.');
+    }
+
     const originalFilename = blob.getName() || 'spreadsheet.xlsx';
     _assertBlobSizeWithinLimit(blob, originalFilename);
 


### PR DESCRIPTION
### Motivation
- Allow spreadsheet files (XLSX, Google Sheets, XLS, ODS) to be included as attachments and ensure Gemini receives a CSV-friendly representation instead of raw binary files.
- Prevent oversized spreadsheet uploads and limit spreadsheet conversion complexity by enforcing cell and file-size limits.

### Description
- Detects spreadsheet MIME types via a new helper `_isSpreadsheetMimeType` and tracks source file/blob in `addFile` to enable different conversion paths for Drive files vs Blob uploads. 
- Converts Google Sheets or uploaded XLSX/ODS/XLS blobs into concatenated, RFC-4180 CSV with sheet metadata using new helpers `_exportGoogleSheetsToCsv`, `_convertXlsxBlobToCsv`, `_spreadsheetToCsvResult`, `_arrayToCsv`, and `_formatSpreadsheetCsvForGemini` and adds `MAX_SPREADSHEET_CELLS` and `_assertBlobSizeWithinLimit` to enforce limits. 
- Emits Gemini-compatible contents using CSV `mime_type: text/csv` and base64-encoded CSV data; preserves OpenAI behavior for input files/images. 
- Extends `_getBlobFromGoogleDrive` allowed mime types to include common spreadsheet formats and keeps existing size checks.

### Testing
- No new automated tests were added for this change. 
- Existing automated test suite (if present in the repository) was executed and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a280a29286083328650634fcf649ebe)