### PR TITLE
Fix Gemini forced function call payload

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -963,7 +963,10 @@ const GenAIApp = (function () {
         }
 
         if (advancedParametersObject?.function_call) {
-          payload.tool_choice = {
+          // The Gemini Interactions API expects forced tool selection under
+          // generation_config.tool_choice. Sending tool_choice at the top level
+          // is rejected as an unknown parameter.
+          payload.generation_config.tool_choice = {
             allowed_tools: {
               mode: "any",
               tools: Array.isArray(advancedParametersObject.function_call)


### PR DESCRIPTION
### Motivation
- Gemini Interactions API returns a 400 error for a top-level `tool_choice` parameter, causing forced `function_call` requests to fail with `Unknown parameter 'tool_choice'`. 
- The change ensures the library places forced tool selection where Gemini expects it, under `generation_config.tool_choice`, to restore function-call forcing for Gemini 2.5 interactions.

### Description
- Move forced function-call selection from `payload.tool_choice` to `payload.generation_config.tool_choice` inside `this._buildGeminiPayload` in `src/code.gs`.
- Preserve the existing normalization for `advancedParametersObject.function_call` into an array and retain the `delete advancedParametersObject.function_call` behavior. 
- Add an inline comment explaining that the Gemini Interactions API rejects a top-level `tool_choice` and requires it under `generation_config`.

### Testing
- Performed a JavaScript syntax check with `node --check` on the modified file, which passed. 
- Ran a Python static assertion script that verifies `payload.tool_choice` is not assigned at the top level and that `payload.generation_config.tool_choice` is present, which succeeded. 
- Ran `git diff --check` to validate there are no whitespace or diff issues, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50c470a5708332934bd9ce8768c5d8)