### PR TITLE
Update samples to gpt-5.6-terra

### DIFF
--- a/samples/configuration-options.gs
+++ b/samples/configuration-options.gs
@@ -15,6 +15,6 @@ function configurationOptionsSample() {
     .setCompactionThreshold(10000)
     .addMessage('Summarize three practical ways to keep AI usage predictable in Apps Script.');
 
-  const response = chat.run({ model: 'gpt-5.4', max_tokens: 800 });
+  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 800 });
   Logger.log(response);
 }

--- a/samples/conversation-continuation.gs
+++ b/samples/conversation-continuation.gs
@@ -9,7 +9,7 @@ function conversationContinuationSample() {
 
   const firstChat = GenAIApp.newChat()
     .addMessage('Remember this preference: my dashboard accent color is teal.');
-  Logger.log(firstChat.run({ model: 'gpt-5.4' }));
+  Logger.log(firstChat.run({ model: 'gpt-5.6-terra' }));
 
   const previousResponseId = firstChat.retrieveLastResponseId();
   Logger.log('Previous response ID: ' + previousResponseId);
@@ -18,6 +18,6 @@ function conversationContinuationSample() {
     .setPreviousResponseId(previousResponseId)
     .addMessage('What accent color did I choose?');
 
-  const response = secondChat.run({ model: 'gpt-5.4' });
+  const response = secondChat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/document-analysis.gs
+++ b/samples/document-analysis.gs
@@ -1,7 +1,7 @@
 /*
  * Purpose: Demonstrates document analysis with addFile() using Drive IDs and Blobs.
  * Use case: Summarize PDFs or exported Google Workspace files from Apps Script.
- * Required config: Store OPENAI_API_KEY and SAMPLE_PDF_FILE_ID in Script Properties.
+ * Required config: Store an OpenAI API key in Script Properties as OPENAI_API_KEY.
  * Expected output: Logs three concise bullets summarizing the supplied documents.
  */
 function documentAnalysisSample() {
@@ -26,6 +26,6 @@ function documentAnalysisSample() {
     .addMessage('Summarize the attached file in three bullets.')
     .addFile(textBlob);
 
-  const response = chat.run({ model: 'gpt-5.4' });
+  const response = chat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/function-calling-advanced.gs
+++ b/samples/function-calling-advanced.gs
@@ -26,7 +26,7 @@ function functionCallingAdvancedSample() {
     .addFunction(extractTicket)
     .addFunction(lookupCustomer);
 
-  const response = chat.run({ model: 'gpt-5.4', function_call: 'extractSupportTicket' });
+  const response = chat.run({ model: 'gpt-5.6-terra', function_call: 'extractSupportTicket' });
   Logger.log(response);
 }
 

--- a/samples/function-calling-basics.gs
+++ b/samples/function-calling-basics.gs
@@ -17,7 +17,7 @@ function functionCallingBasicsSample() {
     .addMessage('What is the weather in Paris? Use the weather function.')
     .addFunction(weatherFunction);
 
-  const response = chat.run({ model: 'gpt-5.4', function_call: 'sampleGetWeather' });
+  const response = chat.run({ model: 'gpt-5.6-terra', function_call: 'sampleGetWeather' });
   Logger.log(response);
 }
 

--- a/samples/google-mcp-connector.gs
+++ b/samples/google-mcp-connector.gs
@@ -4,7 +4,7 @@
  * Required config: Store OPENAI_API_KEY in Script Properties; link Apps Script to a standard GCP project with both Gmail API and Gmail MCP API enabled.
  * Expected output: Logs a concise summary after the model uses the authorized Gmail MCP connector.
  */
-function mcpConnectorsSample() {
+function googleMcpConnectorSample() {
   GenAIApp.setOpenAIAPIKey(PropertiesService.getScriptProperties().getProperty('OPENAI_API_KEY'));
 
   const chat = GenAIApp.newChat()
@@ -19,6 +19,6 @@ function mcpConnectorsSample() {
 
   chat.addMCP(gmailConnector);
 
-  const summary = chat.run({ model: 'gpt-5.4', max_tokens: 10000 });
+  const summary = chat.run({ model: 'gpt-5.6-terra', max_tokens: 10000 });
   Logger.log(summary);
 }

--- a/samples/image-analysis.gs
+++ b/samples/image-analysis.gs
@@ -15,6 +15,6 @@ function imageAnalysisSample() {
     .addImage(imageUrl)
     .addImage(imageBlob);
 
-  const response = chat.run({ model: 'gpt-5.4' });
+  const response = chat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/knowledge-links.gs
+++ b/samples/knowledge-links.gs
@@ -11,6 +11,6 @@ function knowledgeLinksSample() {
     .addKnowledgeLink('https://developers.google.com/apps-script/guides/libraries')
     .addMessage('Based only on the provided knowledge link, what is one reason to use an Apps Script library?');
 
-  const response = chat.run({ model: 'gpt-5.4' });
+  const response = chat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/mcp-connectors.gs
+++ b/samples/mcp-connectors.gs
@@ -17,6 +17,6 @@ function mcpConnectorsSample() {
     .addMCP(calendar)
     .addMCP(drive);
 
-  const response = chat.run({ model: 'gpt-5.4', max_tokens: 20000 });
+  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 20000 });
   Logger.log(response);
 }

--- a/samples/multi-model-usage.gs
+++ b/samples/multi-model-usage.gs
@@ -9,7 +9,7 @@ function multiModelUsageSample() {
   GenAIApp.setOpenAIAPIKey(scriptProperties.getProperty('OPENAI_API_KEY'));
   GenAIApp.setGeminiAPIKey(scriptProperties.getProperty('GEMINI_API_KEY'));
 
-  const models = ['gpt-5.4', 'gemini-3.5-flash', 'o4-mini'];
+  const models = ['gpt-5.6-terra', 'gemini-3.5-flash', 'gpt-5.6-sol'];
   models.forEach(function (model) {
     const chat = GenAIApp.newChat()
       .addMessage('Write a haiku about Apps Script automation.');

--- a/samples/sheets-ai-assistant.gs
+++ b/samples/sheets-ai-assistant.gs
@@ -17,7 +17,7 @@ function sheetsAiAssistantSample() {
   const prompt = 'Analyze this sheet data and return three bullets with key observations:\n' + previewRows;
   const response = GenAIApp.newChat()
     .addMessage(prompt)
-    .run({ model: 'gpt-5.4', max_tokens: 800 });
+    .run({ model: 'gpt-5.6-terra', max_tokens: 800 });
 
   const outputSheet = spreadsheet.getSheetByName('AI Summary') || spreadsheet.insertSheet('AI Summary');
   outputSheet.clear();

--- a/samples/simple-chat.gs
+++ b/samples/simple-chat.gs
@@ -10,6 +10,6 @@ function simpleChatSample() {
   const chat = GenAIApp.newChat();
   chat.addMessage('Say hello in one friendly sentence.');
 
-  const response = chat.run({ model: 'gpt-5.4' });
+  const response = chat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/system-prompts.gs
+++ b/samples/system-prompts.gs
@@ -11,6 +11,6 @@ function systemPromptsSample() {
     .addMessage('You are a patient librarian. Answer in two calm bullet points.', true)
     .addMessage('How should I choose my next book?');
 
-  const response = chat.run({ model: 'gpt-5.4' });
+  const response = chat.run({ model: 'gpt-5.6-terra' });
   Logger.log(response);
 }

--- a/samples/vector-store-rag.gs
+++ b/samples/vector-store-rag.gs
@@ -24,7 +24,7 @@ function vectorStoreRagSample() {
   const answer = GenAIApp.newChat()
     .addVectorStores(vectorStore.getId())
     .addMessage('What is the refund window?')
-    .run({ model: 'gpt-5.4' });
+    .run({ model: 'gpt-5.6-terra' });
   Logger.log(answer);
 
   const chunks = GenAIApp.newChat()
@@ -32,6 +32,6 @@ function vectorStoreRagSample() {
     .onlyReturnChunks(true)
     .setMaxChunks(3)
     .addMessage('refund window')
-    .run({ model: 'gpt-5.4' });
+    .run({ model: 'gpt-5.6-terra' });
   Logger.log(chunks);
 }

--- a/samples/web-browsing.gs
+++ b/samples/web-browsing.gs
@@ -11,6 +11,6 @@ function webBrowsingSample() {
     .enableBrowsing(true, 'https://developers.google.com')
     .addMessage('Find one current Apps Script documentation page about triggers and summarize it in two sentences.');
 
-  const response = chat.run({ model: 'gpt-5.4', max_tokens: 20000 });
+  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 20000 });
   Logger.log(response);
 }


### PR DESCRIPTION
### Motivation
- Bring sample code up to date with the current OpenAI model lineup by replacing older `gpt-5.4` references with the recommended `gpt-5.6-terra` model. 
- Ensure the multi-model comparison sample uses current, reasoning-capable models instead of the deprecated `o4-mini`. 
- Remove misleading setup notes and eliminate a duplicate sample entry-point to keep the examples runnable and unique.

### Description
- Replaced `gpt-5.4` with `gpt-5.6-terra` across the `samples/` directory (examples include `simple-chat`, `vector-store-rag`, `web-browsing`, `function-calling-*`, etc.).
- Updated `samples/multi-model-usage.gs` to use `['gpt-5.6-terra', 'gemini-3.5-flash', 'gpt-5.6-sol']` instead of the older `o4-mini` entry. 
- Renamed the Google-native MCP sample function from `mcpConnectorsSample()` to `googleMcpConnectorSample()` to avoid a duplicate function name collision. 
- Clarified `samples/document-analysis.gs` required configuration by removing an unused `SAMPLE_PDF_FILE_ID` note so the Blob-based example is self-contained.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it passed. 
- Verified all `samples/*.gs` parse syntactically by copying to temporary `.js` files and running `node --check` on each file, which succeeded. 
- Executed a Python validation that confirmed no remaining occurrences of `gpt-5.4` or `o4-mini`, that each sample contains the required metadata (`Purpose:`, `Use case:`, `Expected output:`), and that sample function names are unique, which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a59fb27bf788332b6989c360f1685a9)