### PR TITLE
Make samples provider-neutral and add Gemini interaction continuation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Try [`samples/simple-chat.gs`](samples/simple-chat.gs) first. It is the recommen
 | [`simple-chat.gs`](samples/simple-chat.gs) | Smallest possible GenAIApp chat request for a hello-world smoke test. | `setOpenAIAPIKey()`, `newChat()`, `addMessage()`, `run()` |
 | [`system-prompts.gs`](samples/system-prompts.gs) | Sets assistant role, tone, and response format with a system message. | System messages with `addMessage(message, true)`, prompt shaping |
 | [`configuration-options.gs`](samples/configuration-options.gs) | Shows common configuration and guardrail settings for production scripts. | `disableLogs()`, `warnIfResponseTokenUsageAbove()`, `enableCompaction()`, `setMaximumAPICalls()` |
-| [`multi-model-usage.gs`](samples/multi-model-usage.gs) | Reuses the same prompt across OpenAI and Gemini models for comparison. | `setOpenAIAPIKey()`, `setGeminiAPIKey()`, model selection in `run()` |
+| [`multi-model-usage.gs`](samples/multi-model-usage.gs) | Reuses the same prompt across OpenAI and Gemini model names for comparison. | `setOpenAIAPIKey()`, `setGeminiAPIKey()`, model selection in `run()` |
 | [`vertex-ai-setup.gs`](samples/vertex-ai-setup.gs) | Authenticates Gemini through a linked Google Cloud project instead of an API key. | `setGeminiAuth()`, Vertex AI configuration, Gemini model execution |
 
 ### Content Analysis
@@ -88,9 +88,9 @@ Try [`samples/simple-chat.gs`](samples/simple-chat.gs) first. It is the recommen
 
 | Sample | Description | Demonstrates |
 | --- | --- | --- |
-| [`conversation-continuation.gs`](samples/conversation-continuation.gs) | Continues an OpenAI Responses API conversation without resending the full transcript. | `retrieveLastResponseId()`, `setPreviousResponseId()` |
+| [`conversation-continuation.gs`](samples/conversation-continuation.gs) | Continues OpenAI Responses API and Gemini Interactions API conversations without resending the full transcript. | `retrieveLastResponseId()`, `setPreviousResponseId()`, `retrieveLastInteractionId()`, `setPreviousInteractionId()` |
 | [`configuration-options.gs`](samples/configuration-options.gs) | Configures operational controls for long-running or budget-sensitive automations. | Token warnings, API call limits, compaction thresholds, logging controls |
-| [`multi-model-usage.gs`](samples/multi-model-usage.gs) | Compares outputs from GPT, Gemini, and reasoning models with one prompt. | Multiple model IDs, `reasoning_effort`, provider switching |
+| [`multi-model-usage.gs`](samples/multi-model-usage.gs) | Compares outputs from OpenAI and Gemini model names with one prompt. | Model IDs, provider switching |
 | [`vector-store-rag.gs`](samples/vector-store-rag.gs) | Builds retrieval-augmented generation on OpenAI vector stores. | Vector-store lifecycle, chunking, attributes, retrieval responses |
 | [`openai-vector-store-quickstart.gs`](samples/openai-vector-store-quickstart.gs) | Shows the shortest OpenAI vector-store create-upload-query flow. | OpenAI vector-store IDs, file upload, chat retrieval |
 | [`google-file-search-store-quickstart.gs`](samples/google-file-search-store-quickstart.gs) | Shows the shortest Gemini File Search Store create-upload-query flow. | Gemini store resource names, direct document upload/import, chat retrieval |
@@ -279,7 +279,7 @@ chat.addMCP(customConnector);
 - **Custom MCP servers:** Configure a connector with `.setLabel()`, `.setDescription()`, `.setServerUrl('https://...')`, and optionally `.setAuthorization()` if the server expects a bearer token.
 - **Approval workflows:** `.setRequireApproval('never' | 'domain' | 'always')` lets you enforce end-user approval before the model calls the connector.
 
-> ⚠️ **Model Availability:** MCP connectors are currently available only when you run the chat with OpenAI Responses API models (for example, `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna`).
+> ⚠️ **Model Availability:** MCP connectors are currently available only when you run the chat with OpenAI Responses API models. Check your provider's current model documentation before choosing a model override.
 
 ### Running the Chat
 
@@ -287,16 +287,14 @@ Once you have set up the chat and added the necessary components, start the conv
 
 ```js
 const response = chat.run({
-  model: 'gemini-2.5-flash', // Optional: set the model to use
+  model: 'your-model-name', // Optional: set the model to use
   temperature: 0.5, // Optional: set response creativity
   function_call: 'getWeather' // Optional: force the first API response to call a function
 });
 
 console.log(response);
 ```
-The library supports the following models (this list is not exhaustive):
-1. Gemini: "gemini-2.5-pro" | "gemini-2.5-flash" | "gemini-3.5-flash"
-2. OpenAI: "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+GenAIApp supports compatible Gemini and OpenAI chat models. Model availability changes over time, so check your provider's current documentation before setting a model override.
 
 ⚠️ **Warning:** The `reasoning_effort` parameter is supported only by reasoning-capable OpenAI models and ignored by all others.
 
@@ -390,6 +388,8 @@ A `Chat` represents a conversation with the model.
 - `setMaximumAPICalls(maxAPICalls)`: Limit the number of API calls in a run. See [`samples/configuration-options.gs`](samples/configuration-options.gs).
 - `retrieveLastResponseId()`: Get the last OpenAI response ID returned by `run()`. See [`samples/conversation-continuation.gs`](samples/conversation-continuation.gs).
 - `setPreviousResponseId(id)`: Reuse a previous OpenAI response ID to continue a conversation. See [`samples/conversation-continuation.gs`](samples/conversation-continuation.gs).
+- `retrieveLastInteractionId()`: Get the last Gemini Interactions API interaction ID returned by `run()`. See [`samples/conversation-continuation.gs`](samples/conversation-continuation.gs).
+- `setPreviousInteractionId(id)`: Reuse a previous Gemini interaction ID to continue a conversation. See [`samples/conversation-continuation.gs`](samples/conversation-continuation.gs).
 - `warnIfResponseTokenUsageAbove(input_token_threshold)`: Log a warning if input tokens exceed the threshold. It is off by default.
 - `addVectorStores(vectorStoreIds)`: Attach OpenAI vector store IDs or Gemini File Search Store resource names for retrieval. See [`samples/vector-store-rag.gs`](samples/vector-store-rag.gs), [`samples/openai-vector-store-quickstart.gs`](samples/openai-vector-store-quickstart.gs), and [`samples/google-file-search-store-quickstart.gs`](samples/google-file-search-store-quickstart.gs).
 - `run([advancedParametersObject])`: Execute the chat and return the response. Supports `model`, `temperature`, `reasoning_effort`, `max_tokens`, and `function_call` parameters.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ const response = chat.run({
 
 console.log(response);
 ```
+
 GenAIApp supports compatible Gemini and OpenAI chat models. Model availability changes over time, so check your provider's current documentation before setting a model override.
 
 ⚠️ **Warning:** The `reasoning_effort` parameter is supported only by reasoning-capable OpenAI models and ignored by all others.

--- a/samples/configuration-options.gs
+++ b/samples/configuration-options.gs
@@ -15,6 +15,6 @@ function configurationOptionsSample() {
     .setCompactionThreshold(10000)
     .addMessage('Summarize three practical ways to keep AI usage predictable in Apps Script.');
 
-  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 800 });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/conversation-continuation.gs
+++ b/samples/conversation-continuation.gs
@@ -23,7 +23,7 @@ function conversationContinuationSample() {
 
   const firstGeminiChat = GenAIApp.newChat()
     .addMessage('Remember this preference: my report accent color is amber.');
-  Logger.log(firstGeminiChat.run({ model: 'GeminiModel' }));
+  Logger.log(firstGeminiChat.run({ model: 'gemini-model' }));
 
   const previousInteractionId = firstGeminiChat.retrieveLastInteractionId();
   Logger.log('Previous Gemini interaction ID: ' + previousInteractionId);
@@ -31,5 +31,5 @@ function conversationContinuationSample() {
   const secondGeminiChat = GenAIApp.newChat()
     .setPreviousInteractionId(previousInteractionId)
     .addMessage('What report accent color did I choose?');
-  Logger.log(secondGeminiChat.run({ model: 'GeminiModel' }));
+  Logger.log(secondGeminiChat.run({ model: 'gemini-model' }));
 }

--- a/samples/conversation-continuation.gs
+++ b/samples/conversation-continuation.gs
@@ -1,23 +1,35 @@
 /*
- * Purpose: Demonstrates multi-turn OpenAI conversations with previous response IDs.
- * Use case: Continue a Responses API conversation without resending the whole transcript.
- * Required config: Store an OpenAI API key in Script Properties as OPENAI_API_KEY.
- * Expected output: Logs the first response ID and a second answer that remembers the chosen color.
+ * Purpose: Demonstrates multi-turn OpenAI Responses API and Gemini Interactions API conversations.
+ * Use case: Continue a conversation without resending the whole transcript.
+ * Required config: Store OPENAI_API_KEY and GEMINI_API_KEY in Script Properties.
+ * Expected output: Logs continuation IDs and follow-up answers that remember the chosen colors.
  */
 function conversationContinuationSample() {
-  GenAIApp.setOpenAIAPIKey(PropertiesService.getScriptProperties().getProperty('OPENAI_API_KEY'));
+  const scriptProperties = PropertiesService.getScriptProperties();
+  GenAIApp.setOpenAIAPIKey(scriptProperties.getProperty('OPENAI_API_KEY'));
+  GenAIApp.setGeminiAPIKey(scriptProperties.getProperty('GEMINI_API_KEY'));
 
-  const firstChat = GenAIApp.newChat()
+  const firstOpenAiChat = GenAIApp.newChat()
     .addMessage('Remember this preference: my dashboard accent color is teal.');
-  Logger.log(firstChat.run({ model: 'gpt-5.6-terra' }));
+  Logger.log(firstOpenAiChat.run());
 
-  const previousResponseId = firstChat.retrieveLastResponseId();
-  Logger.log('Previous response ID: ' + previousResponseId);
+  const previousResponseId = firstOpenAiChat.retrieveLastResponseId();
+  Logger.log('Previous OpenAI response ID: ' + previousResponseId);
 
-  const secondChat = GenAIApp.newChat()
+  const secondOpenAiChat = GenAIApp.newChat()
     .setPreviousResponseId(previousResponseId)
     .addMessage('What accent color did I choose?');
+  Logger.log(secondOpenAiChat.run());
 
-  const response = secondChat.run({ model: 'gpt-5.6-terra' });
-  Logger.log(response);
+  const firstGeminiChat = GenAIApp.newChat()
+    .addMessage('Remember this preference: my report accent color is amber.');
+  Logger.log(firstGeminiChat.run({ model: 'GeminiModel' }));
+
+  const previousInteractionId = firstGeminiChat.retrieveLastInteractionId();
+  Logger.log('Previous Gemini interaction ID: ' + previousInteractionId);
+
+  const secondGeminiChat = GenAIApp.newChat()
+    .setPreviousInteractionId(previousInteractionId)
+    .addMessage('What report accent color did I choose?');
+  Logger.log(secondGeminiChat.run({ model: 'GeminiModel' }));
 }

--- a/samples/document-analysis.gs
+++ b/samples/document-analysis.gs
@@ -26,6 +26,6 @@ function documentAnalysisSample() {
     .addMessage('Summarize the attached file in three bullets.')
     .addFile(textBlob);
 
-  const response = chat.run({ model: 'gpt-5.6-terra' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/function-calling-advanced.gs
+++ b/samples/function-calling-advanced.gs
@@ -26,7 +26,7 @@ function functionCallingAdvancedSample() {
     .addFunction(extractTicket)
     .addFunction(lookupCustomer);
 
-  const response = chat.run({ model: 'gpt-5.6-terra', function_call: 'extractSupportTicket' });
+  const response = chat.run({ function_call: 'extractSupportTicket' });
   Logger.log(response);
 }
 

--- a/samples/function-calling-basics.gs
+++ b/samples/function-calling-basics.gs
@@ -17,7 +17,7 @@ function functionCallingBasicsSample() {
     .addMessage('What is the weather in Paris? Use the weather function.')
     .addFunction(weatherFunction);
 
-  const response = chat.run({ model: 'gpt-5.6-terra', function_call: 'sampleGetWeather' });
+  const response = chat.run({ function_call: 'sampleGetWeather' });
   Logger.log(response);
 }
 

--- a/samples/google-file-search-store-quickstart.gs
+++ b/samples/google-file-search-store-quickstart.gs
@@ -20,7 +20,7 @@ function googleFileSearchStoreQuickstartSample() {
   const answer = GenAIApp.newChat()
     .addVectorStores(store.getId())
     .addMessage('When are team demos?')
-    .run();
+    .run({ model: 'gemini-model' });
 
   Logger.log(answer);
 }

--- a/samples/google-file-search-store-quickstart.gs
+++ b/samples/google-file-search-store-quickstart.gs
@@ -20,7 +20,7 @@ function googleFileSearchStoreQuickstartSample() {
   const answer = GenAIApp.newChat()
     .addVectorStores(store.getId())
     .addMessage('When are team demos?')
-    .run({ model: 'gemini-2.5-flash' });
+    .run();
 
   Logger.log(answer);
 }

--- a/samples/google-mcp-connector.gs
+++ b/samples/google-mcp-connector.gs
@@ -19,6 +19,6 @@ function googleMcpConnectorSample() {
 
   chat.addMCP(gmailConnector);
 
-  const summary = chat.run({ model: 'gpt-5.6-terra', max_tokens: 10000 });
+  const summary = chat.run();
   Logger.log(summary);
 }

--- a/samples/image-analysis.gs
+++ b/samples/image-analysis.gs
@@ -15,6 +15,6 @@ function imageAnalysisSample() {
     .addImage(imageUrl)
     .addImage(imageBlob);
 
-  const response = chat.run({ model: 'gpt-5.6-terra' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/knowledge-links.gs
+++ b/samples/knowledge-links.gs
@@ -11,6 +11,6 @@ function knowledgeLinksSample() {
     .addKnowledgeLink('https://developers.google.com/apps-script/guides/libraries')
     .addMessage('Based only on the provided knowledge link, what is one reason to use an Apps Script library?');
 
-  const response = chat.run({ model: 'gpt-5.6-terra' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/mcp-connectors.gs
+++ b/samples/mcp-connectors.gs
@@ -17,6 +17,6 @@ function mcpConnectorsSample() {
     .addMCP(calendar)
     .addMCP(drive);
 
-  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 20000 });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/multi-model-usage.gs
+++ b/samples/multi-model-usage.gs
@@ -9,7 +9,7 @@ function multiModelUsageSample() {
   GenAIApp.setOpenAIAPIKey(scriptProperties.getProperty('OPENAI_API_KEY'));
   GenAIApp.setGeminiAPIKey(scriptProperties.getProperty('GEMINI_API_KEY'));
 
-  const models = ['openAIModel', 'GeminiModel'];
+  const models = ['openai-model', 'gemini-model'];
   models.forEach(function (model) {
     const chat = GenAIApp.newChat()
       .addMessage('Write a haiku about Apps Script automation.');

--- a/samples/multi-model-usage.gs
+++ b/samples/multi-model-usage.gs
@@ -1,6 +1,6 @@
 /*
  * Purpose: Demonstrates reusing the same chat setup with different models.
- * Use case: Compare GPT, Gemini, and reasoning-model responses without changing prompts.
+ * Use case: Compare OpenAI and Gemini responses without changing prompts.
  * Required config: Store OPENAI_API_KEY and GEMINI_API_KEY in Script Properties.
  * Expected output: Logs one response per model for the same haiku-generation prompt.
  */
@@ -9,12 +9,12 @@ function multiModelUsageSample() {
   GenAIApp.setOpenAIAPIKey(scriptProperties.getProperty('OPENAI_API_KEY'));
   GenAIApp.setGeminiAPIKey(scriptProperties.getProperty('GEMINI_API_KEY'));
 
-  const models = ['gpt-5.6-terra', 'gemini-3.5-flash', 'gpt-5.6-sol'];
+  const models = ['openAIModel', 'GeminiModel'];
   models.forEach(function (model) {
     const chat = GenAIApp.newChat()
       .addMessage('Write a haiku about Apps Script automation.');
 
-    const response = chat.run({ model: model, reasoning_effort: 'low' });
+    const response = chat.run({ model: model });
     Logger.log(model + ': ' + response);
   });
 }

--- a/samples/openai-vector-store-quickstart.gs
+++ b/samples/openai-vector-store-quickstart.gs
@@ -20,7 +20,7 @@ function openAiVectorStoreQuickstartSample() {
   const answer = GenAIApp.newChat()
     .addVectorStores(store.getId())
     .addMessage('What support is included with paid plans?')
-    .run({ model: 'gpt-5.6-terra' });
+    .run();
 
   Logger.log(answer);
 }

--- a/samples/sheets-ai-assistant.gs
+++ b/samples/sheets-ai-assistant.gs
@@ -17,7 +17,7 @@ function sheetsAiAssistantSample() {
   const prompt = 'Analyze this sheet data and return three bullets with key observations:\n' + previewRows;
   const response = GenAIApp.newChat()
     .addMessage(prompt)
-    .run({ model: 'gpt-5.6-terra', max_tokens: 800 });
+    .run();
 
   const outputSheet = spreadsheet.getSheetByName('AI Summary') || spreadsheet.insertSheet('AI Summary');
   outputSheet.clear();

--- a/samples/simple-chat.gs
+++ b/samples/simple-chat.gs
@@ -10,6 +10,6 @@ function simpleChatSample() {
   const chat = GenAIApp.newChat();
   chat.addMessage('Say hello in one friendly sentence.');
 
-  const response = chat.run({ model: 'gpt-5.6-terra' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/system-prompts.gs
+++ b/samples/system-prompts.gs
@@ -11,6 +11,6 @@ function systemPromptsSample() {
     .addMessage('You are a patient librarian. Answer in two calm bullet points.', true)
     .addMessage('How should I choose my next book?');
 
-  const response = chat.run({ model: 'gpt-5.6-terra' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/vector-store-rag.gs
+++ b/samples/vector-store-rag.gs
@@ -24,7 +24,7 @@ function vectorStoreRagSample() {
   const answer = GenAIApp.newChat()
     .addVectorStores(vectorStore.getId())
     .addMessage('What is the refund window?')
-    .run({ model: 'gpt-5.6-terra' });
+    .run();
   Logger.log(answer);
 
   const chunks = GenAIApp.newChat()
@@ -32,6 +32,6 @@ function vectorStoreRagSample() {
     .onlyReturnChunks(true)
     .setMaxChunks(3)
     .addMessage('refund window')
-    .run({ model: 'gpt-5.6-terra' });
+    .run();
   Logger.log(chunks);
 }

--- a/samples/vertex-ai-setup.gs
+++ b/samples/vertex-ai-setup.gs
@@ -14,6 +14,6 @@ function vertexAiSetupSample() {
   const chat = GenAIApp.newChat()
     .addMessage('Explain Vertex AI authentication for Apps Script in one sentence.');
 
-  const response = chat.run();
+  const response = chat.run({ model: 'gemini-model' });
   Logger.log(response);
 }

--- a/samples/vertex-ai-setup.gs
+++ b/samples/vertex-ai-setup.gs
@@ -14,6 +14,6 @@ function vertexAiSetupSample() {
   const chat = GenAIApp.newChat()
     .addMessage('Explain Vertex AI authentication for Apps Script in one sentence.');
 
-  const response = chat.run({ model: 'gemini-2.5-flash' });
+  const response = chat.run();
   Logger.log(response);
 }

--- a/samples/web-browsing.gs
+++ b/samples/web-browsing.gs
@@ -11,6 +11,6 @@ function webBrowsingSample() {
     .enableBrowsing(true, 'https://developers.google.com')
     .addMessage('Find one current Apps Script documentation page about triggers and summarize it in two sentences.');
 
-  const response = chat.run({ model: 'gpt-5.6-terra', max_tokens: 20000 });
+  const response = chat.run();
   Logger.log(response);
 }


### PR DESCRIPTION
### Motivation
- Reduce hardcoded model names in docs and samples to avoid stale provider-specific examples and encourage using project defaults or explicit model overrides. 
- Add support for continuing Gemini Interactions API conversations alongside OpenAI Responses API flows. 
- Clarify MCP connector availability wording to avoid implying a fixed set of supported models. 

### Description
- Update `README.md` to remove/neutralize explicit model lists and add documentation for `retrieveLastInteractionId()` and `setPreviousInteractionId()` and a provider-agnostic model availability note. 
- Extend the conversation continuation sample (`samples/conversation-continuation.gs`) to demonstrate both OpenAI Responses API and Gemini Interactions API flows and to use `retrieveLastResponseId()`/`setPreviousResponseId()` and `retrieveLastInteractionId()`/`setPreviousInteractionId()` respectively. 
- Remove hardcoded model IDs from many sample scripts and replace `chat.run({ model: '...' })` calls with `chat.run()` or a generic placeholder (for example in `samples/simple-chat.gs`, `samples/image-analysis.gs`, `samples/multi-model-usage.gs`, and others). 
- Simplify multi-model sample to use generic model names and remove `reasoning_effort` from the example, and standardize how API keys and script properties are loaded across samples. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a609536653483328f5e4afdf98ad9f2)