### PR TITLE
Remove deprecated sampling parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ Once you have set up the chat and added the necessary components, start the conv
 ```js
 const response = chat.run({
   model: 'your-model-name', // Optional: set the model to use
-  temperature: 0.5, // Optional: set response creativity
   function_call: 'getWeather' // Optional: force the first API response to call a function
 });
 
@@ -393,7 +392,7 @@ A `Chat` represents a conversation with the model.
 - `setPreviousInteractionId(id)`: Reuse a previous Gemini interaction ID to continue a conversation. See [`samples/conversation-continuation.gs`](samples/conversation-continuation.gs).
 - `warnIfResponseTokenUsageAbove(input_token_threshold)`: Log a warning if input tokens exceed the threshold. It is off by default.
 - `addVectorStores(vectorStoreIds)`: Attach OpenAI vector store IDs or Gemini File Search Store resource names for retrieval. See [`samples/vector-store-rag.gs`](samples/vector-store-rag.gs), [`samples/openai-vector-store-quickstart.gs`](samples/openai-vector-store-quickstart.gs), and [`samples/google-file-search-store-quickstart.gs`](samples/google-file-search-store-quickstart.gs).
-- `run([advancedParametersObject])`: Execute the chat and return the response. Supports `model`, `temperature`, `reasoning_effort`, `max_tokens`, and `function_call` parameters.
+- `run([advancedParametersObject])`: Execute the chat and return the response. Supports `model`, `reasoning_effort`, `max_tokens`, and `function_call` parameters.
 
 ### Function Object
 

--- a/src/code.gs
+++ b/src/code.gs
@@ -46,8 +46,6 @@ const GenAIApp = (function () {
       const tools = [];
       const mcpConnectors = [];
       let model = "gpt-5.6-terra"; // default
-      //  OpenAI & Gemini models support a temperature value between 0.0 and 2.0. Models have a default temperature of 1.0.
-      let temperature = 1;
       let max_tokens = 1000;
       let browsing = false;
       let reasoning_effort = "medium";
@@ -458,7 +456,6 @@ const GenAIApp = (function () {
           messages: messages,
           tools: tools,
           model: model,
-          temperature: temperature,
           max_tokens: max_tokens,
           browsing: browsing,
           compaction_enabled: compaction_enabled,
@@ -474,9 +471,8 @@ const GenAIApp = (function () {
        * Sends all your messages and eventual function to chat GPT.
        * Will return the last chat answer.
        * If a function calling model is used, will call several functions until the chat decides that nothing is left to do.
-       * @param {Object} [advancedParametersObject] OPTIONAL - For more advanced settings and specific usage only. {model, temperature, function_call}
+       * @param {Object} [advancedParametersObject] OPTIONAL - For more advanced settings and specific usage only. {model, reasoning_effort, max_tokens, function_call}
        * @param {"gemini-3.1-pro-preview" | "gemini-3.1-flash-lite" | "gemini-3.5-flash" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"} [advancedParametersObject.model]
-       * @param {number} [advancedParametersObject.temperature]
        * @param {"low" | "medium" | "high"} [advancedParametersObject.reasoning_effort] Only needed for OpenAI reasoning models, defaults to medium
        * @param {number} [advancedParametersObject.max_tokens]
        * @param {string} [advancedParametersObject.function_call]
@@ -490,7 +486,6 @@ const GenAIApp = (function () {
         this._lastGeneratedDriveFileUrl = null;
 
         model = advancedParametersObject?.model ?? model;
-        temperature = advancedParametersObject?.temperature ?? temperature;
         max_tokens = advancedParametersObject?.max_tokens ?? max_tokens;
         reasoning_effort = advancedParametersObject?.reasoning_effort ?? reasoning_effort;
 
@@ -946,8 +941,7 @@ const GenAIApp = (function () {
           model: model,
           input: _geminiContentsToInteractionInput(previous_interaction_id ? contents.slice(last_gemini_content_count) : contents),
           generation_config: {
-            max_output_tokens: max_tokens,
-            temperature: temperature
+            max_output_tokens: max_tokens
           },
           tools: []
         };


### PR DESCRIPTION
### Motivation
- Sampling parameters such as `temperature` (and related sampling settings) are deprecated and should not be stored, sent, or documented by the `GenAIApp` chat wrapper.
- Remove deprecated state and payload fields to avoid sending unsupported parameters to provider APIs and to keep the public API docs accurate.

### Description
- Remove the `temperature` state from `GenAIApp.Chat` and stop serializing it in the chat JSON returned by `_toJson`.
- Stop reading `advancedParametersObject.temperature` in `run()` so the chat no longer accepts or applies a `temperature` override.
- Remove `temperature` from the Gemini `generation_config` payload built by `_buildGeminiPayload` so it is no longer sent to the Gemini Interactions API.
- Update the `run()` JSDoc and `README.md` example/API reference to list only supported advanced parameters (`model`, `reasoning_effort`, `max_tokens`, and `function_call`).

### Testing
- Ran `git diff --check` which produced no whitespace/errors and succeeded.
- Performed a syntax check with `node --check < src/code.gs` which succeeded with no parse errors.
- Verified deprecated sampling references are absent using ripgrep searches over `src` and `README.md`, which returned no remaining references to `temperature`, `top_p`, or `top_k` in the modified files.
- Confirmed working tree status after committing the changes with `git status --short` and committed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a670e2be11883328d1ada96a422e509)