### PR TITLE
Retry Gemini invalid JSON responses with repair prompt

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -1862,13 +1862,14 @@ const GenAIApp = (function () {
         }
       }
       const responseCode = response.getResponseCode();
+      const responseText = response.getContentText();
 
       if (responseCode === 200) {
         if (returnRawResponse) {
           return response;
         }
         // The request was successful, exit the loop.
-        const parsedResponse = JSON.parse(response.getContentText());
+        const parsedResponse = JSON.parse(responseText);
         if (endpoint.includes("google")) {
           responseMessage = parsedResponse;
           finish_reason = parsedResponse.status
@@ -1884,6 +1885,18 @@ const GenAIApp = (function () {
           console.warn(`[GenAIApp] - ${payload.model} response could not be completed because of an insufficient amount of tokens. To resolve this issue, you can increase the amount of tokens like this : chat.run({max_tokens: XXXX}).`);
         }
         success = true;
+      }
+      else if (endpoint.includes("google") && _isGeminiInvalidJsonError(responseText)) {
+        const errorMessage = _extractApiErrorMessage(responseText);
+        const retryInstruction = `Your previous response failed JSON parsing with error: ${errorMessage}. Please ensure all tool calls and JSON outputs are strictly valid JSON with properly escaped characters.`;
+        payload.input = Array.isArray(payload.input) ? payload.input : [];
+        payload.input.push({
+          type: "user_input",
+          content: [{ type: "text", text: retryInstruction }]
+        });
+        retries++;
+        console.warn(`[GenAIApp] - Gemini returned invalid JSON, retrying with the parsing error in the prompt (${retries}/${maxRetries}).`);
+        continue;
       }
       else if (responseCode === 400 && hasMcpConnectors) {
         // Retry on context_length_exceeded ONLY when MCP connectors are present.
@@ -1936,6 +1949,30 @@ const GenAIApp = (function () {
       });
     }
     return responseMessage;
+  }
+
+  /**
+   * Returns the most useful message from an API error response.
+   * @param {string} responseText - Raw API response body.
+   * @returns {string} Parsed error message, or the raw response when it is not JSON.
+   */
+  function _extractApiErrorMessage(responseText) {
+    try {
+      const errorResponse = JSON.parse(responseText);
+      return errorResponse?.error?.message || errorResponse?.message || responseText;
+    }
+    catch (e) {
+      return responseText;
+    }
+  }
+
+  /**
+   * Identifies Gemini's model-output JSON parsing failure.
+   * @param {string} responseText - Raw API response body.
+   * @returns {boolean} Whether the response reports invalid generated JSON.
+   */
+  function _isGeminiInvalidJsonError(responseText) {
+    return /Model generated invalid JSON syntax and the output could not be parsed/i.test(_extractApiErrorMessage(responseText));
   }
 
   /**

--- a/src/code.gs
+++ b/src/code.gs
@@ -1862,12 +1862,12 @@ const GenAIApp = (function () {
         }
       }
       const responseCode = response.getResponseCode();
+      if (responseCode === 200 && returnRawResponse) {
+        return response;
+      }
       const responseText = response.getContentText();
 
       if (responseCode === 200) {
-        if (returnRawResponse) {
-          return response;
-        }
         // The request was successful, exit the loop.
         const parsedResponse = JSON.parse(responseText);
         if (endpoint.includes("google")) {
@@ -1967,11 +1967,39 @@ const GenAIApp = (function () {
   }
 
   /**
+   * Extracts Gemini's machine-readable error code from common error response shapes.
+   * @param {string} responseText - Raw Gemini API response body.
+   * @returns {string|null} Normalized Gemini error code, when available.
+   */
+  function _extractGeminiErrorCode(responseText) {
+    try {
+      const errorResponse = JSON.parse(responseText);
+      const error = errorResponse?.error || errorResponse;
+      const details = Array.isArray(error?.details) ? error.details : [];
+      const code = [
+        error?.code,
+        error?.reason,
+        error?.error_code,
+        error?.errorCode,
+        ...details.flatMap(detail => [detail?.reason, detail?.error_code, detail?.errorCode, detail?.code])
+      ].find(value => typeof value === "string" && value.length > 0);
+      return code ? code.toLowerCase() : null;
+    }
+    catch (e) {
+      return null;
+    }
+  }
+
+  /**
    * Identifies Gemini's model-output JSON parsing failure.
    * @param {string} responseText - Raw API response body.
    * @returns {boolean} Whether the response reports invalid generated JSON.
    */
   function _isGeminiInvalidJsonError(responseText) {
+    const errorCode = _extractGeminiErrorCode(responseText);
+    if (errorCode === "malformed_function_call" || errorCode === "malformed_tool_call") {
+      return true;
+    }
     return /Model generated invalid JSON syntax and the output could not be parsed/i.test(_extractApiErrorMessage(responseText));
   }
 

--- a/src/code.gs
+++ b/src/code.gs
@@ -1843,23 +1843,30 @@ const GenAIApp = (function () {
       }
 
       let response;
-      // if the ErrorHandler library is loaded and supports backoff, use it (https://github.com/RomainVialard/ErrorHandler)
-      if (typeof ErrorHandler !== 'undefined' && typeof ErrorHandler.urlFetchWithExpBackOff === 'function') {
-        response = ErrorHandler.urlFetchWithExpBackOff(endpoint, options);
-      }
-      else {
-        try {
+      try {
+        // if the ErrorHandler library is loaded and supports backoff, use it (https://github.com/RomainVialard/ErrorHandler)
+        if (typeof ErrorHandler !== 'undefined' && typeof ErrorHandler.urlFetchWithExpBackOff === 'function') {
+          response = ErrorHandler.urlFetchWithExpBackOff(endpoint, options);
+        }
+        else {
           response = UrlFetchApp.fetch(endpoint, options);
         }
-        catch (err) {
-          if (verbose) {
-            console.warn(`[GenAIApp] - Network error calling ${payload.model}: ${err.message}. Retrying (${retries + 1}/${maxRetries})`);
-          }
-          const delay = Math.pow(2, retries) * 1000;
-          Utilities.sleep(delay);
+      }
+      catch (err) {
+        const errorText = err?.message || String(err);
+        if (endpoint.includes("google") && _isGeminiInvalidJsonError(errorText)) {
+          _appendGeminiJsonRetryInstruction(payload, errorText);
           retries++;
+          console.warn(`[GenAIApp] - Gemini returned invalid JSON, retrying with the parsing error in the prompt (${retries}/${maxRetries}).`);
           continue;
         }
+        if (verbose) {
+          console.warn(`[GenAIApp] - Network error calling ${payload.model}: ${errorText}. Retrying (${retries + 1}/${maxRetries})`);
+        }
+        const delay = Math.pow(2, retries) * 1000;
+        Utilities.sleep(delay);
+        retries++;
+        continue;
       }
       const responseCode = response.getResponseCode();
       if (responseCode === 200 && returnRawResponse) {
@@ -1887,13 +1894,7 @@ const GenAIApp = (function () {
         success = true;
       }
       else if (endpoint.includes("google") && _isGeminiInvalidJsonError(responseText)) {
-        const errorMessage = _extractApiErrorMessage(responseText);
-        const retryInstruction = `Your previous response failed JSON parsing with error: ${errorMessage}. Please ensure all tool calls and JSON outputs are strictly valid JSON with properly escaped characters.`;
-        payload.input = Array.isArray(payload.input) ? payload.input : [];
-        payload.input.push({
-          type: "user_input",
-          content: [{ type: "text", text: retryInstruction }]
-        });
+        _appendGeminiJsonRetryInstruction(payload, responseText);
         retries++;
         console.warn(`[GenAIApp] - Gemini returned invalid JSON, retrying with the parsing error in the prompt (${retries}/${maxRetries}).`);
         continue;
@@ -1967,26 +1968,53 @@ const GenAIApp = (function () {
   }
 
   /**
+   * Adds Gemini's JSON parsing failure and repair guidance to the next request.
+   * @param {Object} payload - Gemini request payload to update.
+   * @param {string} responseText - Raw API response or thrown error text.
+   */
+  function _appendGeminiJsonRetryInstruction(payload, responseText) {
+    const errorMessage = _extractApiErrorMessage(responseText);
+    const retryInstruction = `Your previous response failed JSON parsing with error: ${errorMessage}. Please ensure all tool calls and JSON outputs are strictly valid JSON with properly escaped characters.`;
+    payload.input = Array.isArray(payload.input) ? payload.input : [];
+    payload.input.push({
+      type: "user_input",
+      content: [{ type: "text", text: retryInstruction }]
+    });
+  }
+
+  /**
    * Extracts Gemini's machine-readable error code from common error response shapes.
    * @param {string} responseText - Raw Gemini API response body.
    * @returns {string|null} Normalized Gemini error code, when available.
    */
   function _extractGeminiErrorCode(responseText) {
+    const recognizedCodes = ["malformed_function_call", "malformed_tool_call"];
     try {
       const errorResponse = JSON.parse(responseText);
-      const error = errorResponse?.error || errorResponse;
-      const details = Array.isArray(error?.details) ? error.details : [];
-      const code = [
-        error?.code,
-        error?.reason,
-        error?.error_code,
-        error?.errorCode,
-        ...details.flatMap(detail => [detail?.reason, detail?.error_code, detail?.errorCode, detail?.code])
-      ].find(value => typeof value === "string" && value.length > 0);
-      return code ? code.toLowerCase() : null;
+      let fallbackCode = null;
+
+      function findCode(value, key) {
+        if (typeof value === "string") {
+          const normalizedValue = value.toLowerCase();
+          if (recognizedCodes.includes(normalizedValue)) return normalizedValue;
+          if (!fallbackCode && ["code", "reason", "error_code", "errorcode"].includes(String(key).toLowerCase())) {
+            fallbackCode = normalizedValue;
+          }
+          return null;
+        }
+        if (!value || typeof value !== "object") return null;
+        for (const childKey of Object.keys(value)) {
+          const code = findCode(value[childKey], childKey);
+          if (code) return code;
+        }
+        return null;
+      }
+
+      return findCode(errorResponse, null) || fallbackCode;
     }
     catch (e) {
-      return null;
+      const codeMatch = String(responseText).match(/malformed_(?:function|tool)_call/i);
+      return codeMatch ? codeMatch[0].toLowerCase() : null;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Gemini model responses sometimes return the error "Model generated invalid JSON syntax and the output could not be parsed", causing the client to fail parsing without a targeted retry instruction.

### Description
- Reuse the raw response body by assigning `response.getContentText()` to `responseText` and parse from that value when successful.
- Detect Gemini model-generated invalid-JSON errors with `_isGeminiInvalidJsonError(responseText)` and extract a useful message via `_extractApiErrorMessage(responseText)`.
- When such an error is detected, append a `user_input` repair instruction containing the exact parsing error to `payload.input`, increment `retries`, and retry the request while preserving existing retry/backoff behavior.
- Added two helper functions `_extractApiErrorMessage` and `_isGeminiInvalidJsonError` in `src/code.gs` to centralize error extraction and matching logic.

### Testing
- Ran `git diff --check` which produced no check errors and returned successfully.
- Ran `cp src/code.gs /tmp/genaiapp-code.js && node --check /tmp/genaiapp-code.js` to validate JavaScript syntax and it succeeded.
- Ran repository sanity checks `git status --short` and `git log -1 --oneline` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8fd69ec800833280cd76b04cc03a32)