### PR TITLE
Do not dispatch Gemini built-in tool calls as local functions

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -655,10 +655,7 @@ const GenAIApp = (function () {
         if (tools.length > 0) {
           // Check if AI model wanted to call a function
           if (model.includes("gemini")) {
-            // Gemini reports server-side built-in tool activity (for example,
-            // `google:file_search`) as function_call steps too. Only locally
-            // execute calls whose names match functions registered on this chat.
-            const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
+            const functionCalls = _extractGeminiFunctionCalls(responseMessage);
             if (functionCalls.length > 0) {
               contents = _handleGeminiToolCalls(responseMessage, tools, contents);
               // check if endWithResults or onlyReturnArguments
@@ -2145,7 +2142,7 @@ const GenAIApp = (function () {
     return part?.text || responseMessage?.output_text || null;
   }
 
-  function _extractGeminiFunctionCalls(responseMessage, tools) {
+  function _extractGeminiFunctionCalls(responseMessage) {
     const calls = [];
     const steps = responseMessage?.steps || [];
     steps.forEach(step => {
@@ -2157,7 +2154,7 @@ const GenAIApp = (function () {
       });
     });
     if (calls.length > 0) {
-      return _filterRegisteredGeminiFunctionCalls(calls, tools);
+      return _filterGeminiBuiltInFunctionCalls(calls);
     }
 
     // Backward-compatible fallback for legacy content-shaped responses.
@@ -2171,24 +2168,21 @@ const GenAIApp = (function () {
         });
       }
     });
-    return _filterRegisteredGeminiFunctionCalls(calls, tools);
+    return _filterGeminiBuiltInFunctionCalls(calls);
   }
 
   /**
-   * Filters Gemini function-call steps to functions that the caller registered.
-   * Gemini's Interactions API also represents server-executed built-in tools such
-   * as `google:file_search` as function calls; those must not be dispatched via
-   * the Apps Script global scope.
+   * Removes Gemini server-executed built-in tool steps from local function calls.
+   * Built-in functions use Google's reserved `google:` namespace and must not be
+   * dispatched through the Apps Script global scope. Other calls remain eligible
+   * for the existing dynamic lookup so globally defined functions continue to
+   * work even when their declaration metadata is unavailable at response time.
    *
    * @param {Array} calls - Function calls extracted from a Gemini response.
-   * @param {Array|undefined} tools - Locally registered function tools. When
-   * omitted, calls are returned unchanged for backward compatibility.
-   * @returns {Array} Calls that correspond to locally registered functions.
+   * @returns {Array} Calls that are not in Google's built-in namespace.
    */
-  function _filterRegisteredGeminiFunctionCalls(calls, tools) {
-    if (!Array.isArray(tools)) return calls;
-    const registeredNames = new Set(tools.map(tool => tool.function._toJson().name));
-    return calls.filter(call => registeredNames.has(call.name));
+  function _filterGeminiBuiltInFunctionCalls(calls) {
+    return calls.filter(call => !String(call.name || "").startsWith("google:"));
   }
 
   /**
@@ -2211,7 +2205,7 @@ const GenAIApp = (function () {
    * @returns {Object} - Tool continuation input and state flags for the Chat run loop.
    */
   function _handleGeminiToolCalls(responseMessage, tools, contents) {
-    const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
+    const functionCalls = _extractGeminiFunctionCalls(responseMessage);
     const functionResults = [];
     let shouldEndWithResult = false;
     let onlyReturnArguments = null;

--- a/src/code.gs
+++ b/src/code.gs
@@ -655,7 +655,10 @@ const GenAIApp = (function () {
         if (tools.length > 0) {
           // Check if AI model wanted to call a function
           if (model.includes("gemini")) {
-            const functionCalls = _extractGeminiFunctionCalls(responseMessage);
+            // Gemini reports server-side built-in tool activity (for example,
+            // `google:file_search`) as function_call steps too. Only locally
+            // execute calls whose names match functions registered on this chat.
+            const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
             if (functionCalls.length > 0) {
               contents = _handleGeminiToolCalls(responseMessage, tools, contents);
               // check if endWithResults or onlyReturnArguments
@@ -2142,7 +2145,7 @@ const GenAIApp = (function () {
     return part?.text || responseMessage?.output_text || null;
   }
 
-  function _extractGeminiFunctionCalls(responseMessage) {
+  function _extractGeminiFunctionCalls(responseMessage, tools) {
     const calls = [];
     const steps = responseMessage?.steps || [];
     steps.forEach(step => {
@@ -2153,7 +2156,9 @@ const GenAIApp = (function () {
         args: step.args || step.arguments || step.function?.arguments || step.functionCall?.args || {}
       });
     });
-    if (calls.length > 0) return calls;
+    if (calls.length > 0) {
+      return _filterRegisteredGeminiFunctionCalls(calls, tools);
+    }
 
     // Backward-compatible fallback for legacy content-shaped responses.
     const parts = responseMessage?.parts || [];
@@ -2166,7 +2171,24 @@ const GenAIApp = (function () {
         });
       }
     });
-    return calls;
+    return _filterRegisteredGeminiFunctionCalls(calls, tools);
+  }
+
+  /**
+   * Filters Gemini function-call steps to functions that the caller registered.
+   * Gemini's Interactions API also represents server-executed built-in tools such
+   * as `google:file_search` as function calls; those must not be dispatched via
+   * the Apps Script global scope.
+   *
+   * @param {Array} calls - Function calls extracted from a Gemini response.
+   * @param {Array|undefined} tools - Locally registered function tools. When
+   * omitted, calls are returned unchanged for backward compatibility.
+   * @returns {Array} Calls that correspond to locally registered functions.
+   */
+  function _filterRegisteredGeminiFunctionCalls(calls, tools) {
+    if (!Array.isArray(tools)) return calls;
+    const registeredNames = new Set(tools.map(tool => tool.function._toJson().name));
+    return calls.filter(call => registeredNames.has(call.name));
   }
 
   /**
@@ -2189,7 +2211,7 @@ const GenAIApp = (function () {
    * @returns {Object} - Tool continuation input and state flags for the Chat run loop.
    */
   function _handleGeminiToolCalls(responseMessage, tools, contents) {
-    const functionCalls = _extractGeminiFunctionCalls(responseMessage);
+    const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
     const functionResults = [];
     let shouldEndWithResult = false;
     let onlyReturnArguments = null;

--- a/src/code.gs
+++ b/src/code.gs
@@ -655,7 +655,7 @@ const GenAIApp = (function () {
         if (tools.length > 0) {
           // Check if AI model wanted to call a function
           if (model.includes("gemini")) {
-            const functionCalls = _extractGeminiFunctionCalls(responseMessage);
+            const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
             if (functionCalls.length > 0) {
               contents = _handleGeminiToolCalls(responseMessage, tools, contents);
               // check if endWithResults or onlyReturnArguments
@@ -2142,7 +2142,7 @@ const GenAIApp = (function () {
     return part?.text || responseMessage?.output_text || null;
   }
 
-  function _extractGeminiFunctionCalls(responseMessage) {
+  function _extractGeminiFunctionCalls(responseMessage, tools) {
     const calls = [];
     const steps = responseMessage?.steps || [];
     steps.forEach(step => {
@@ -2154,7 +2154,7 @@ const GenAIApp = (function () {
       });
     });
     if (calls.length > 0) {
-      return _filterGeminiBuiltInFunctionCalls(calls);
+      return _filterGeminiBuiltInFunctionCalls(calls, tools);
     }
 
     // Backward-compatible fallback for legacy content-shaped responses.
@@ -2168,21 +2168,24 @@ const GenAIApp = (function () {
         });
       }
     });
-    return _filterGeminiBuiltInFunctionCalls(calls);
+    return _filterGeminiBuiltInFunctionCalls(calls, tools);
   }
 
   /**
    * Removes Gemini server-executed built-in tool steps from local function calls.
    * Built-in functions use Google's reserved `google:` namespace and must not be
-   * dispatched through the Apps Script global scope. Other calls remain eligible
-   * for the existing dynamic lookup so globally defined functions continue to
-   * work even when their declaration metadata is unavailable at response time.
+   * dispatched through the Apps Script global scope. When registered tools are
+   * provided, calls must also match the registered function allowlist.
    *
    * @param {Array} calls - Function calls extracted from a Gemini response.
-   * @returns {Array} Calls that are not in Google's built-in namespace.
+   * @param {Array|undefined} tools - Locally registered function tools.
+   * @returns {Array} Calls eligible for local execution.
    */
-  function _filterGeminiBuiltInFunctionCalls(calls) {
-    return calls.filter(call => !String(call.name || "").startsWith("google:"));
+  function _filterGeminiBuiltInFunctionCalls(calls, tools) {
+    const nonGoogleCalls = calls.filter(call => !String(call.name || "").startsWith("google:"));
+    if (!Array.isArray(tools)) return nonGoogleCalls;
+    const registeredNames = new Set(tools.map(tool => tool.function._toJson().name));
+    return nonGoogleCalls.filter(call => registeredNames.has(call.name));
   }
 
   /**
@@ -2205,7 +2208,7 @@ const GenAIApp = (function () {
    * @returns {Object} - Tool continuation input and state flags for the Chat run loop.
    */
   function _handleGeminiToolCalls(responseMessage, tools, contents) {
-    const functionCalls = _extractGeminiFunctionCalls(responseMessage);
+    const functionCalls = _extractGeminiFunctionCalls(responseMessage, tools);
     const functionResults = [];
     let shouldEndWithResult = false;
     let onlyReturnArguments = null;

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -107,9 +107,15 @@ function _geminiTextResponse(id, text, status = "completed") {
   };
 }
 
+let geminiUnregisteredFunctionCallCount = 0;
+function unregisteredGeminiFunction() {
+  geminiUnregisteredFunctionCallCount++;
+}
+
 function testGeminiBuiltInToolCallsAreNotDispatchedLocally() {
   GenAIApp.setGeminiAPIKey("mock-gemini-key");
   _runSingleTest("Gemini built-in tool dispatch", "gemini", () => {
+    geminiUnregisteredFunctionCallCount = 0;
     const requests = [];
     const chat = GenAIApp.newChat().disableLogs(true);
     const localFunction = GenAIApp.newFunction()
@@ -127,6 +133,12 @@ function testGeminiBuiltInToolCallsAreNotDispatchedLocally() {
           args: { queries: ["team demos"] }
         },
         {
+          type: "function_call",
+          id: "unregistered-global-call",
+          name: "unregisteredGeminiFunction",
+          args: {}
+        },
+        {
           type: "model_output",
           content: [{ type: "text", text: "Team demos happen every Friday at 10 AM." }]
         }
@@ -140,6 +152,9 @@ function testGeminiBuiltInToolCallsAreNotDispatchedLocally() {
     }
     if (requests.length !== 1) {
       throw new Error("Built-in tool activity unexpectedly triggered a continuation request");
+    }
+    if (geminiUnregisteredFunctionCallCount !== 0) {
+      throw new Error("An unregistered global function was dispatched locally");
     }
     return "OK";
   });

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -72,6 +72,7 @@ function testAll() {
   testInputTokenWarning();
   if (_shouldRunModelLabel("gemini")) {
     testGeminiInteractionRequestPayloads();
+    testGeminiBuiltInToolCallsAreNotDispatchedLocally();
     testGeminiFailedInteractionState();
     testGeminiInteractionThreading();
     testGeminiRetrieveLastInteractionId();
@@ -103,6 +104,44 @@ function _geminiTextResponse(id, text, status = "completed") {
     status,
     steps: text ? [{ type: "model_output", content: [{ type: "text", text }] }] : []
   };
+}
+
+function testGeminiBuiltInToolCallsAreNotDispatchedLocally() {
+  GenAIApp.setGeminiAPIKey("mock-gemini-key");
+  _runSingleTest("Gemini built-in tool dispatch", "gemini", () => {
+    const requests = [];
+    const chat = GenAIApp.newChat().disableLogs(true);
+    const localFunction = GenAIApp.newFunction()
+      .setName("getWeather")
+      .setDescription("Get weather")
+      .addParameter("cityName", "string", "City name");
+    chat._apiCaller = _mockGeminiApiCaller([{
+      id: "file-search-interaction",
+      status: "completed",
+      steps: [
+        {
+          type: "function_call",
+          id: "built-in-file-search-call",
+          name: "google:file_search",
+          args: { queries: ["team demos"] }
+        },
+        {
+          type: "model_output",
+          content: [{ type: "text", text: "Team demos happen every Friday at 10 AM." }]
+        }
+      ]
+    }], requests);
+
+    chat.addMessage("When are team demos?").addFunction(localFunction);
+    const response = chat.run({ model: GEMINI_MODEL, max_tokens: TEST_MAX_TOKENS });
+    if (response !== "Team demos happen every Friday at 10 AM.") {
+      throw new Error("Gemini built-in file search was treated as a local function call");
+    }
+    if (requests.length !== 1) {
+      throw new Error("Built-in tool activity unexpectedly triggered a continuation request");
+    }
+    return "OK";
+  });
 }
 
 function testGeminiInteractionRequestPayloads() {

--- a/src/testFunctions.gs
+++ b/src/testFunctions.gs
@@ -73,6 +73,7 @@ function testAll() {
   if (_shouldRunModelLabel("gemini")) {
     testGeminiInteractionRequestPayloads();
     testGeminiBuiltInToolCallsAreNotDispatchedLocally();
+    testGeminiGlobalFunctionCallsRemainEligible();
     testGeminiFailedInteractionState();
     testGeminiInteractionThreading();
     testGeminiRetrieveLastInteractionId();
@@ -139,6 +140,43 @@ function testGeminiBuiltInToolCallsAreNotDispatchedLocally() {
     }
     if (requests.length !== 1) {
       throw new Error("Built-in tool activity unexpectedly triggered a continuation request");
+    }
+    return "OK";
+  });
+}
+
+function testGeminiGlobalFunctionCallsRemainEligible() {
+  GenAIApp.setGeminiAPIKey("mock-gemini-key");
+  _runSingleTest("Gemini global function dispatch", "gemini", () => {
+    const requests = [];
+    const chat = GenAIApp.newChat().disableLogs(true);
+    const functionDeclaration = GenAIApp.newFunction()
+      .setName("getWeather")
+      .setDescription("Get weather")
+      .addParameter("cityName", "string", "City name");
+    chat._apiCaller = _mockGeminiApiCaller([
+      {
+        id: "function-interaction-1",
+        status: "completed",
+        steps: [{
+          type: "function_call",
+          id: "weather-call-1",
+          name: "getWeather",
+          args: { cityName: "Paris" }
+        }]
+      },
+      _geminiTextResponse("function-interaction-2", "It is 19°C in Paris.")
+    ], requests);
+
+    chat.addMessage("What's the weather in Paris?").addFunction(functionDeclaration);
+    const response = chat.run({ model: GEMINI_MODEL, max_tokens: TEST_MAX_TOKENS });
+    if (response !== "It is 19°C in Paris.") {
+      throw new Error("Gemini local function was not called");
+    }
+    if (requests.length !== 2
+      || requests[1].payload.input?.[0]?.name !== "getWeather"
+      || requests[1].payload.input?.[0]?.result?.[0]?.text !== "The weather in Paris is 19°C today.") {
+      throw new Error("Gemini local function result was not sent back to the model");
     }
     return "OK";
   });


### PR DESCRIPTION
### Motivation
- The Gemini Interactions API can represent server-executed built-in tools (for example `google:file_search`) as `function_call` steps, which were previously dispatched into the Apps Script global scope and could trigger unintended local function execution.
- The change prevents built-in tool activity from being treated as locally-registered function calls and avoids spurious continuation requests.

### Description
- Updated `_extractGeminiFunctionCalls` to accept a `tools` argument and return only calls matching locally registered functions by name.
- Added `_filterRegisteredGeminiFunctionCalls` to filter out Gemini server-side built-in tool calls (preserving backward compatibility when `tools` is omitted).
- Propagated `tools` into the Gemini handling call sites so built-in calls are not forwarded to `_callFunction`.
- Added a regression test `testGeminiBuiltInToolCallsAreNotDispatchedLocally` and registered it in `testAll` to ensure built-in `google:file_search` activity is not dispatched locally and that the model output is returned normally.

### Testing
- Ran `git diff --check` to validate the patch format and file diffs, which succeeded.
- Ran `node --check` on `src/code.gs` and `src/testFunctions.gs` to validate syntax, which succeeded.
- Executed the regression test by running the combined test script and observed `PASS: Gemini built-in tool dispatch [gemini] - OK`, confirming the new test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a991920cd908332bf32e3af1422e175)