### PR TITLE
Support tool combination for OpenAI and Gemini

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -760,7 +760,7 @@ const GenAIApp = (function () {
           payload.previous_response_id = previous_response_id;
         }
 
-        if (tool_combination_enabled) {
+        if (tool_combination_enabled && privateInstanceBaseUrl) {
           payload.include_server_side_tool_invocations = true;
         }
 
@@ -997,12 +997,6 @@ const GenAIApp = (function () {
         // the full previous contents array.
         if (previous_interaction_id) {
           payload.previous_interaction_id = previous_interaction_id;
-        }
-
-        if (tool_combination_enabled) {
-          payload.tool_config = {
-            include_server_side_tool_invocations: true
-          };
         }
 
         if (advancedParametersObject?.function_call) {

--- a/src/code.gs
+++ b/src/code.gs
@@ -1001,7 +1001,7 @@ const GenAIApp = (function () {
 
         if (tool_combination_enabled) {
           payload.tool_config = {
-            includeServerSideToolInvocations: true
+            include_server_side_tool_invocations: true
           };
         }
 

--- a/src/code.gs
+++ b/src/code.gs
@@ -331,7 +331,7 @@ const GenAIApp = (function () {
 
        /** OPTIONAL
        *
-       * Enable or disable server-side tool invocations for Gemini (Tool Combination).
+       * Enable or disable server-side tool invocations (Tool Combination).
        * @param {boolean} enabled - True to enable tool combination.
        * @returns {Chat} - The current Chat instance.
        */
@@ -760,6 +760,10 @@ const GenAIApp = (function () {
           payload.previous_response_id = previous_response_id;
         }
 
+        if (tool_combination_enabled) {
+          payload.include_server_side_tool_invocations = true;
+        }
+
         let systemInstructions = "";
         const userMessages = [];
         for (const message of messages) {
@@ -996,7 +1000,9 @@ const GenAIApp = (function () {
         }
 
         if (tool_combination_enabled) {
-          payload.include_server_side_tool_invocations = true;
+          payload.tool_config = {
+            includeServerSideToolInvocations: true
+          };
         }
 
         if (advancedParametersObject?.function_call) {


### PR DESCRIPTION
### Motivation
- Provide parity between OpenAI and Gemini tool-combination behavior so the same `enableToolCombination()` method controls server-side tool invocations for both providers.
- Make the smallest change necessary to wire the Gemini equivalent without altering public API or existing behavior for OpenAI.

### Description
- Updated `src/code.gs` documentation for `enableToolCombination()` to reflect provider-agnostic behavior.
- When `tool_combination_enabled` is true, `_buildOpenAIPayload()` now sets `payload.include_server_side_tool_invocations = true` for OpenAI requests.
- When `tool_combination_enabled` is true, `_buildGeminiPayload()` now sets `payload.tool_config = { includeServerSideToolInvocations: true }` to send the Gemini-equivalent flag.
- Changes are minimal and localized to `src/code.gs` and preserve existing payload construction logic and public APIs.

### Testing
- Ran `git diff --check` and it produced no issues, and the working tree is clean, indicating no leftover whitespace/conflicts.
- Ran syntax check with `node --check < src/code.gs` which succeeded with no parse errors.
- Verified repository status with `git status --short` showing a clean working state after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a9fb0d48a348332ad6cfc87f28661a9)