### PR TITLE
Use v1 for Gemini Interactions API calls

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -568,17 +568,17 @@ const GenAIApp = (function () {
             if (geminiKey) {
               // Public endpoint / Generative Language API
               // https://console.cloud.google.com/apis/api/generativelanguage.googleapis.com
-              endpointUrl = `https://generativelanguage.googleapis.com/v1beta/interactions`;
+              endpointUrl = `https://generativelanguage.googleapis.com/v1/interactions`;
             }
             else {
               // Enterprise endpoint / Vertex AI API
               // https://console.cloud.google.com/apis/api/aiplatform.googleapis.com
               // requires scope "https://www.googleapis.com/auth/cloud-platform.read-only" in access token
               if (!region || model.includes("gemini-3")) { // Gemini 3 requires global endpoint when using Vertex AI API
-                endpointUrl = `https://aiplatform.googleapis.com/v1beta1/projects/${gcpProjectId}/locations/global/interactions`;
+                endpointUrl = `https://aiplatform.googleapis.com/v1/projects/${gcpProjectId}/locations/global/interactions`;
               }
               else {
-                endpointUrl = `https://${region}-aiplatform.googleapis.com/v1beta1/projects/${gcpProjectId}/locations/${region}/interactions`;
+                endpointUrl = `https://${region}-aiplatform.googleapis.com/v1/projects/${gcpProjectId}/locations/${region}/interactions`;
               }
             }
           }


### PR DESCRIPTION
### Motivation
- Move Gemini Interactions API requests to the stable `v1` endpoints for both the public Generative Language API and Vertex AI so the library targets the current API version.

### Description
- Updated the public endpoint `https://generativelanguage.googleapis.com/v1beta/interactions` to `https://generativelanguage.googleapis.com/v1/interactions` and changed Vertex AI endpoints from `v1beta1` to `v1` (global and regional) in `src/code.gs`.

### Testing
- Ran `node --check < src/code.gs` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa00cfa44ec8332bfa465697f1d3378)