### PR TITLE
Retry Gemini tool call limit errors

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -1820,6 +1820,12 @@ const GenAIApp = (function () {
         }
         success = true;
       }
+      else if (endpoint.includes("google") && _isGeminiToolCallLimitError(response.getContentText())) {
+        _appendGeminiToolCallLimitRetryInstruction(payload, response.getContentText());
+        retries++;
+        console.warn(`[GenAIApp] - Gemini generated too many tool calls, retrying with the API error in the prompt (${retries}/${maxRetries}).`);
+        continue;
+      }
       else if (responseCode === 400 && hasMcpConnectors) {
         // Retry on context_length_exceeded ONLY when MCP connectors are present.
         let errJson = null;
@@ -1871,6 +1877,45 @@ const GenAIApp = (function () {
       });
     }
     return responseMessage;
+  }
+
+  /**
+   * Returns the most useful message from an API error response.
+   * @param {string} responseText - Raw API response body.
+   * @returns {string} Parsed error message, or the raw response when it is not JSON.
+   */
+  function _extractApiErrorMessage(responseText) {
+    try {
+      const errorResponse = JSON.parse(responseText);
+      return errorResponse?.error?.message || errorResponse?.message || responseText;
+    }
+    catch (e) {
+      return responseText;
+    }
+  }
+
+  /**
+   * Adds Gemini's tool-call limit guidance to the next request.
+   * @param {Object} payload - Gemini request payload to update.
+   * @param {string} responseText - Raw API response body.
+   */
+  function _appendGeminiToolCallLimitRetryInstruction(payload, responseText) {
+    const errorMessage = _extractApiErrorMessage(responseText);
+    const retryInstruction = `The previous request failed with this Gemini error: ${errorMessage} Retry the task using only the minimum necessary tool calls and a valid number of tool calls.`;
+    payload.input = Array.isArray(payload.input) ? payload.input : [];
+    payload.input.push({
+      type: "user_input",
+      content: [{ type: "text", text: retryInstruction }]
+    });
+  }
+
+  /**
+   * Identifies Gemini's recoverable model tool-call limit error.
+   * @param {string} responseText - Raw Gemini API response body.
+   * @returns {boolean} Whether the response reports too many generated tool calls.
+   */
+  function _isGeminiToolCallLimitError(responseText) {
+    return /Model generated too many tool calls/i.test(_extractApiErrorMessage(responseText));
   }
 
   /**


### PR DESCRIPTION
When Gemini returns "Model generated too many tool calls", the request currently fails immediately. This change recognizes that response and retries within the existing five-attempt budget, appending Google's error message and an instruction to use the minimum necessary tool calls.

The retry preserves the existing request context, tool declarations, and previous interaction ID. This handles returned API errors; it does not add handling for exceptions thrown by the optional ErrorHandler wrapper.

Validation: JavaScript syntax and `git diff --check` passed. A mocked Gemini 400-to-success flow confirmed the error message is included in the retry prompt.
